### PR TITLE
Override potentially broken x86 vcvars inside VS2019 built-in PowerShells

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -49,20 +49,16 @@ Write-Host "Using Visual Studio installation at: ${vsPath}" -ForegroundColor Yel
 #
 # Make sure the Visual Studio Command Prompt variables are set.
 #
-If (Test-Path env:LIBPATH) {
-  Write-Host "Visual Studio Command Prompt variables already set." -ForegroundColor Yellow
-} Else {
-  # Load VC vars
-  Push-Location "${vsPath}\VC\Auxiliary\Build"
-  cmd /c "vcvarsall.bat x64&set" |
-    ForEach-Object {
-      If ($_ -match "=") {
-        $v = $_.split("="); Set-Item -Force -Path "ENV:\$($v[0])" -Value "$($v[1])"
-      }
-    }
-  Pop-Location
-  Write-Host "Visual Studio Command Prompt variables set." -ForegroundColor Yellow
+# Load VC vars
+Push-Location "${vsPath}\VC\Auxiliary\Build"
+cmd /c "vcvarsall.bat x64&set" |
+ForEach-Object {
+  If ($_ -match "=") {
+	$v = $_.split("="); Set-Item -Force -Path "ENV:\$($v[0])" -Value "$($v[1])"
+  }
 }
+Pop-Location
+Write-Host "Visual Studio Command Prompt variables set." -ForegroundColor Yellow
 
 function PerformBuild {
 	param(


### PR DESCRIPTION
This commit removes the check for `LIBPATH` every time common is inherited by other scripts, allowing common to set the correct `x64` variables by default, instead of the inevitable case where a user is using the built-in VS2019 PowerShell terminal (inside the IDE or outside).

Such terminals will have `LIBPATH` already set for `x86` by default, and if not, `LIBPATH` will definitely be set, thus causing further errors. There have been some users that have run into this on the discord.

I guess you could argue this _should_ be enforced on all PowerShell build runs anyway (opinion), provided you are using the common build files, other users could fork their own.