### PR TITLE
Update imgui.cpp to prevent Remix Menu nullptr crash

### DIFF
--- a/src/dxvk/imgui/imgui.cpp
+++ b/src/dxvk/imgui/imgui.cpp
@@ -9040,10 +9040,14 @@ ImGuiWindow* ImGui::GetTopMostAndVisiblePopupModal()
     return NULL;
 }
 
-void ImGui::OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags)
-{
-    ImGuiContext& g = *GImGui;
+void ImGui::OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags) {
+  ImGuiContext& g = *GImGui;
+  if (g.CurrentWindow != nullptr) {
     OpenPopupEx(g.CurrentWindow->GetID(str_id), popup_flags);
+  }
+  else {
+    //Logger::warn("Attempted to open a nullptr ImGui window, ignoring.");
+  }
 }
 
 void ImGui::OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags)


### PR DESCRIPTION
Removed a nullptr reference that triggered a crash when opening the Remix menu if no current window was set. Current cause for the nullptr is unknown.  Adding this check was enough to make Sword and Fairy 4 load into gameplay without crashing, and made the Remix menu available for use.  However the reason for the error occurring to begin with is unknown and this commit probably needs more work.

Logger is commented out as this script is imgui related (not DXVK related) and doesn't appear to have Logger references, ideally this should be revised so that the reason behind the nullptr value can be tracked down.