### PR TITLE
dxvk_imgui.cpp - Lightmap/Hide Instance in UI

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -140,8 +140,11 @@ namespace dxvk {
   std::vector<RtxTextureOption> rtxTextureOptions = {
     {"uitextures", "UI Texture", &RtxOptions::Get()->uiTexturesObject()},
     {"worldspaceuitextures", "World Space UI Texture", &RtxOptions::Get()->worldSpaceUiTexturesObject()},
+   // {"worldspaceuibackgroundtextures", "World Space UI Background Texture", &RtxOptions::Get()->worldSpaceUiBackgroundTexturesObject()},
     {"skytextures", "Sky Texture", &RtxOptions::Get()->skyBoxTexturesObject()},
     {"ignoretextures", "Ignore Texture (optional)", &RtxOptions::Get()->ignoreTexturesObject()},
+    {"hidetextures", "Hide Texture Instance (optional)", &RtxOptions::Get()->hideInstanceTexturesObject()},
+    {"lightmaptextures","Lightmap Textures (optional)", &RtxOptions::Get()->lightmapTexturesObject()},
     {"ignorelights", "Ignore Lights (optional)", &RtxOptions::Get()->ignoreLightsObject()},
     {"particletextures", "Particle Texture (optional)", &RtxOptions::Get()->particleTexturesObject()},
     {"beamtextures", "Beam Texture (optional)", &RtxOptions::Get()->beamTexturesObject()},


### PR DESCRIPTION
*Note: An earlier commit was submitted from a different branch of the fork; this has now been remedied.*

Added two/three tags that were missing from the Texture UI but supported by Remix:
- Lightmap texture (optional)
- Hide Instance
- World Space UI Background Texture (commented out)

Due to the different behaviors of Lightmap Texture and Hide Instance I recommend exposing them to users to potentially improve compatibility in cases where hiding lightmaps as Ignore Textures causes additional rendering issues.

Deny this commit if hiding was intended.