### PR TITLE
allow `enableRaytracing` UI toggle and config option

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -1925,7 +1925,6 @@ namespace dxvk {
       auto& dlss = common->metaDLSS();
       ImGui::Indent();
 
-#ifdef REMIX_DEVELOPMENT
       ImGui::Checkbox("Raytracing Enabled", & RtxOptions::Get()->enableRaytracingObject()); 
 
       renderPassGBufferRaytraceModeCombo.getKey(&RtxOptions::Get()->renderPassGBufferRaytraceModeObject());
@@ -1933,7 +1932,6 @@ namespace dxvk {
       renderPassIntegrateIndirectRaytraceModeCombo.getKey(&RtxOptions::Get()->renderPassIntegrateIndirectRaytraceModeObject());
 
       ImGui::Separator();
-#endif
 
       showReflexOptions(true);
 

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -205,15 +205,11 @@ namespace dxvk {
                   "Defines which hashes we need to include when sampling from replacements and doing USD capture.");
     
   public:
-#ifdef REMIX_DEVELOPMENT
     // Note, this is currently a debug option we don't want to support in shipping config
     RTX_OPTION_ENV("rtx", bool, enableRaytracing, true, "DXVK_ENABLE_RAYTRACING",
                    "Globally enables or disables ray tracing. When set to false the original game should render mostly as it would in DXVK typically.\n"
                    "Some artifacts may still appear however compared to the original game either due to issues with the underlying DXVK translation or issues in Remix itself.");
-#else
-    // Shipping config
-    bool enableRaytracing() { return true; }
-#endif
+
 
     RTX_OPTION_ENV("rtx", float, timeDeltaBetweenFrames, 0.f, "RTX_FRAME_TIME_DELTA_MS", "Frame time delta to use during scene processing. Setting this to 0 will use actual frame time delta for a given frame. Non-zero value is primarily used for automation to ensure determinism run to run.");
 


### PR DESCRIPTION
This commit allows the `enableRaytracing` toggle and configuration option to be exposed regardless of build setting. This follows on a internal discussion about comparisons. Please also see the linked issue [#213](https://github.com/NVIDIAGameWorks/rtx-remix/issues/213) regarding this change, as a debugOptimized build will need further optimizations to remain truly "optimized" for general use, especially for the vulkan validation layers setting. it looks like meson may also need to be updated to reflect a debugoptimized build selection.