### PR TITLE
CI/CD - Create Rolling Releases automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main, automatic-releases ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, automatic-releases ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,10 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "automatic${{matrix.build-flavour}}"
+        automatic_release_tag: "automatic-${{matrix.build-flavour}}"
         prerelease: true
         title: "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 
-          _output/*.dll
-          _output/*.pdb
-          _output/*.txt
+          ${{matrix.output-subdir}}/*.dll
+          ${{matrix.output-subdir}}/*.pdb
+          ${{matrix.output-subdir}}/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,10 @@ jobs:
             output-subdir: _Comp64Release
     steps:
     - uses: "marvinpinto/action-automatic-releases@latest"
+      permissions: write-all
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "automatic-${{matrix.build-flavour}}"
+        automatic_release_tag: "automatic${{matrix.build-flavour}}"
         prerelease: true
         title: "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           _output\*.txt
 
     - name: "Prune automatic CI/CD releases to latest"
-      uses: dev-drprasad/delete-older-releases@latest
+      uses: dev-drprasad/delete-older-releases@v0.2.1
       with:
         repo: anchorlightforge/dxvk-remix # defaults to current repo
         keep_latest: 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,9 @@ jobs:
             output-subdir: _Comp64DebugOptimized
           - build-flavour: release
             output-subdir: _Comp64Release
+    permissions: write-all
     steps:
     - uses: "marvinpinto/action-automatic-releases@latest"
-      permissions: write-all
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "automatic${{matrix.build-flavour}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           _output\*.txt
 
     - name: "Prune automatic CI/CD releases to latest"
-      uses: dev-drprasad/delete-older-releases@v0.2
+      uses: dev-drprasad/delete-older-releases@latest
       with:
         repo: anchorlightforge/dxvk-remix # defaults to current repo
         keep_latest: 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,9 +56,9 @@ jobs:
     - name: "Prune automatic CI/CD releases to latest"
       uses: dev-drprasad/delete-older-releases@v0.2
       with:
-      repo: anchorlightforge/dxvk-remix # defaults to current repo
-      keep_latest: 2
-      delete_tag_pattern: automatic # defaults to ""
+        repo: anchorlightforge/dxvk-remix # defaults to current repo
+        keep_latest: 2
+        delete_tag_pattern: automatic # defaults to ""
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Copy readme
       run: copy artifacts_readme.txt _output
     
-    - name: Upload binaries
+    - name: Upload binaries as artifact
       uses: actions/upload-artifact@v3
       with:
         name: dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}
@@ -67,7 +67,7 @@ jobs:
     - name: "Prune automatic CI/CD releases to latest"
       uses: dev-drprasad/delete-older-releases@v0.2.1
       with:
-        keep_latest: 2
+        keep_latest: 3
         delete_tag_pattern: automatic # defaults to ""
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,16 @@ jobs:
           _output\*.pdb
           _output\*.txt
 
-    - name: "Automate GitHub release"
+    - name: "Prune automatic CI/CD releases to latest"
+      uses: dev-drprasad/delete-older-releases@v0.2
+      with:
+      repo: anchorlightforge/dxvk-remix # defaults to current repo
+      keep_latest: 2
+      delete_tag_pattern: automatic # defaults to ""
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Create new CI/CD release"
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -61,6 +70,6 @@ jobs:
         prerelease: true
         title: "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 
-          ${{matrix.output-subdir}}/*.dll
-          ${{matrix.output-subdir}}/*.pdb
-          ${{matrix.output-subdir}}/*.txt
+          _output/*.dll
+          _output/*.pdb
+          _output/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "pre-release"
+        automatic_release_tag: "automatic-${{matrix.build-flavour}}"
         prerelease: true
         title: "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
   release:
     runs-on: windows-2022
-    needs: [ build ]
+    needs: [ build-windows ]
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,20 @@ jobs:
           _output\*.pdb
           _output\*.txt
 
+    - name: Create clean directory for CI/CD release 
+      shell: pwsh
+      run: |
+        New-Item ".\_release" -Type Directory
+        cd ".\_release"
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.pdb | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.dll | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.txt | Copy-Item
+        cd ".."
+        Compress-Archive -Path ".\_release\*" -DestinationPath "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}.zip"
+
     - name: "Prune automatic CI/CD releases to latest"
       uses: dev-drprasad/delete-older-releases@v0.2.1
       with:
-        repo: anchorlightforge/dxvk-remix # defaults to current repo
         keep_latest: 2
         delete_tag_pattern: automatic # defaults to ""
       env:
@@ -70,6 +80,5 @@ jobs:
         prerelease: true
         title: "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 
-          _output/*.dll
-          _output/*.pdb
-          _output/*.txt
+          *.zip
+          _release/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,28 @@ jobs:
           _output\*.dll
           _output\*.pdb
           _output\*.txt
+
+
+  release:
+    runs-on: windows-2022
+    needs: [ build ]
+    strategy:
+      matrix:
+        include:
+          - build-flavour: debug
+            output-subdir: _Comp64Debug
+          - build-flavour: debugoptimized
+            output-subdir: _Comp64DebugOptimized
+          - build-flavour: release
+            output-subdir: _Comp64Release
+    steps:
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
+        files: | 
+          _output/*.dll
+          _output/*.pdb
+          _output/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-windows:
     runs-on: windows-2022
-
+    permissions: write-all
     strategy:
       matrix:
         include:
@@ -53,22 +53,8 @@ jobs:
           _output\*.pdb
           _output\*.txt
 
-
-  release:
-    runs-on: windows-2022
-    needs: [ build-windows ]
-    strategy:
-      matrix:
-        include:
-          - build-flavour: debug
-            output-subdir: _Comp64Debug
-          - build-flavour: debugoptimized
-            output-subdir: _Comp64DebugOptimized
-          - build-flavour: release
-            output-subdir: _Comp64Release
-    permissions: write-all
-    steps:
-    - uses: "marvinpinto/action-automatic-releases@latest"
+    - name: "Automate GitHub release"
+      uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "automatic-${{matrix.build-flavour}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
+        automatic_release_tag: "pre-release"
         prerelease: true
         title: "dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 


### PR DESCRIPTION
A number of users working on scripts and other automatic workflows have run into issues trying to install DXVK-Remix due to the fact that GitHub Actions are now locked behind a login wall as of 2020.  A few functions exist to access the info through the API but they all appear to turn up errors for anyone who has tried to use them.

In this PR I have altered the build script in order to automatically generate a rolling release.  The steps up to the workflow should be untouched; however, after the upload process is complete for artifacts, there is a new set of steps where GitHub Actions does the following:
- Creates a new folder called _release/ which is _output/ sanitized of clutter, only containing the dll/pdb/txt files
- Creates a zip with this folder
- Deletes all but the last three automatic uploads
- Uploads this folder to the specified target

While I wish I could push all three ZIPs into a single release I am still investigating how to do so as each build is treated like a separate environment.
