### PR TITLE
CI/CD - Automatic Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   build-windows:
     runs-on: windows-2022
-
+    permissions: 
+      contents: write
     strategy:
       matrix:
         include:
@@ -44,11 +45,46 @@ jobs:
     - name: Copy readme
       run: copy artifacts_readme.txt _output
     
-    - name: Upload binaries
+    - name: Upload binaries as artifact
       uses: actions/upload-artifact@v3
       with:
-        name: dxvk-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}
+        name: dxvk-remix-${{github.run_number}}-${{env.GITHUB_SHA_SHORT}}-${{matrix.build-flavour}}
         path: |
           _output\*.dll
           _output\*.pdb
           _output\*.txt
+
+    - name: Create clean directory for CI/CD release 
+      shell: pwsh
+      run: |
+        New-Item ".\_upload" -Type Directory
+        cd ".\_upload"
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.pdb | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.dll | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.txt | Copy-Item
+        New-Item ".\.trex" -Type Directory
+        cd ".\.trex"
+        Get-ChildItem -Path "..\*.dll" | Move-Item
+        Get-ChildItem -Path "..\*.pdb" | Move-Item
+        cd "..\.."
+        Compress-Archive -Path ".\_upload\*" -DestinationPath "dxvk-remix-${{github.run_number}}-${{env.GITHUB_SHA_SHORT}}-${{matrix.build-flavour}}.zip"
+
+    - name: "Prune automatic CI/CD releases to latest"
+      uses: dev-drprasad/delete-older-releases@v0.2.1
+      with:
+        keep_latest: 3
+        delete_tag_pattern: automatic # defaults to ""
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Create new CI/CD release"
+      uses: "softprops/action-gh-release@v1"
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: "automatic-${{matrix.build-flavour}}"
+        prerelease: true
+        generate_release_notes: true
+        name: "dxvk-remix-automatic-${{matrix.build-flavour}}"
+        files: | 
+          *.zip
+          _upload/*.txt

--- a/cicd_clean_output.ps1
+++ b/cicd_clean_output.ps1
@@ -1,0 +1,4 @@
+New-Item ".\_release" -Type Directory
+Get-ChildItem -Path ".\_output" -Recurse -Filter *.pdb | Copy-Item
+Get-ChildItem -Path ".\_output" -Recurse -Filter *.dll | Copy-Item
+Get-ChildItem -Path ".\_output" -Recurse -Filter *.txt | Copy-Item

--- a/cicd_clean_output.ps1
+++ b/cicd_clean_output.ps1
@@ -1,4 +1,0 @@
-New-Item ".\_release" -Type Directory
-Get-ChildItem -Path ".\_output" -Recurse -Filter *.pdb | Copy-Item
-Get-ChildItem -Path ".\_output" -Recurse -Filter *.dll | Copy-Item
-Get-ChildItem -Path ".\_output" -Recurse -Filter *.txt | Copy-Item


### PR DESCRIPTION
A number of users working on scripts and other automatic workflows have run into issues trying to install DXVK-Remix due to the fact that GitHub Actions are now locked behind a login wall as of 2020. A few functions exist to access the info through the API but they all appear to turn up errors for anyone who has tried to use them.

In this PR I have altered the build script in order to automatically generate a rolling release. The steps up to the workflow should be untouched; however, after the upload process is complete for artifacts, there is a new set of steps where GitHub Actions does the following:

- Creates a new folder called _release/ which is _output/ sanitized of clutter, only containing the dll/pdb/txt files
- Creates a zip with this folder
- Uploads this folder to the automatic releases page
- Adjusts the artifacts' names to sort properly when listed in A-Z order

A previous PR existed for the same purpose; this PR has a different set of dependencies that offer a less cluttered release page and no deprecated calls.  It also cleans up the dxvk-remix release repo for first time users, and compresses the ZIP before upload to reduce the download size significantly.  If desired this can be applied to the artifact upload as well.