### PR TITLE
bug_report.md: redirect to main repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,28 +7,6 @@ assignees: ''
 
 ---
 
-Please describe your issue as accurately as possible. If you run into a problem with a binary release, make sure to test with latest `master` as well.
+Please describe your issue as accurately as possible. If you run into a problem with a binary release, make sure to test with latest `main` as well.
 
-**Important:** When reporting an issue with a specific game or application, such as crashes or rendering issues, please include log files and, if possible, a D3D11/D3D9 Apitrace (see https://github.com/apitrace/apitrace) so that the issue can be reproduced.
-In order to create a trace for **D3D11/D3D10**: Run `wine apitrace.exe trace -a dxgi YOURGAME.exe`.
-In order to create a trace for **D3D9**: Follow https://github.com/Joshua-Ashton/d9vk/wiki/Making-a-Trace.
-Preferably record the trace on Windows, or wined3d if possible.
-
-**Reports with no log files will be ignored.**
-
-### Software information
-Name of the game, settings used etc.
-
-### System information
-- GPU:
-- Driver:
-- Wine version: 
-- DXVK version: 
-
-### Apitrace file(s)
-- Put a link here
-
-### Log files
-- d3d9.log:
-- d3d11.log:
-- dxgi.log:
+**Important:** In most cases, DXVK-Remix reports should be sent to the combined RTX-Remix Issues page: https://github.com/NVIDIAGameWorks/rtx-remix/issues


### PR DESCRIPTION
This is a simple PR that adds a link to the RTX Remix repo in place of the default DXVK bug report template.

This template was created by doitsujin for the original DXVK project and goes against RTX Remix recommendations.  The info has now been replaced with a link to the RTX Remix repository Issues page so that users are directed to report issues to the right place.