### PR TITLE
Remove the whitespace in "[Foliage System] (/documentation/FoliageSystem.md)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ While dxvk-remix is a fork of DXVK, please report bugs encountered with dxvk-rem
 - [Rtx Options](/RtxOptions.md)
 - [Terrain System](/documentation/TerrainSystem.md)
 - [Anti-Culling System](/documentation/AntiCullingSystem.md)
-- [Foliage System] (/documentation/FoliageSystem.md)
+- [Foliage System](/documentation/FoliageSystem.md)
 - [Unit Test](/documentation/UnitTest.md)


### PR DESCRIPTION
Correcting the link syntax for proper formatting in preview. The corrected line is under:
https://github.com/NVIDIAGameWorks/dxvk-remix#project-documentation