### PR TITLE
Additional Conf Presets

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -894,6 +894,18 @@ namespace dxvk {
     { R"(\\ROGame\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
     }} },
+    /* Bully: Scholarship Edition uses three untextured calls for its skybox */
+    { R"(\\Bully\.exe$)",{{
+      { "rtx.skyDrawcallIdThreshold",       "3"      },
+    }} },
+    /* Driver: Parallel Lines crash prevention  */
+    { R"(\\DriverParallelLines\.exe$)",{{
+      { "d3d9.deferSurfaceCreation",       "False"   },
+    }} },
+    /* Sword and Fairy 4 flickering fix         */
+    { R"(\\PAL4\.exe$)",{{
+    { "d3d9.noExplicitFrontBuffer",        "True"    },
+    }} },
     /* Dark Souls II                            */
     { R"(\\DarkSoulsII\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },


### PR DESCRIPTION
Added a few conf presets to select games:
- Bully: Will automatically mark the first three untextured draw calls, fixing the sky rendering [a relatively simple in-game fix]
- Driver Parallel Lines: Prevents a startup crash with the default dxvk.conf settings, see https://github.com/NVIDIAGameWorks/rtx-remix/issues/272
- Sword and Fairy 4 (PAL4): Removes the backbuffer to prevent a flicker every other frame