### PR TITLE
ImGui Font Scaling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ imgui-scaleall ]
   pull_request:
     branches: [ main ]
 

--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -119,6 +119,7 @@ namespace ImGui {
 
   // The value for width is arbitrary. But it looks nice.
   void TextSeparator(char* text, float pre_width = 10.0f) {
+    //pre_width *= RtxOptions::menuFontScale();
     ImGui::PreSeparator(pre_width);
     ImGui::Text(text);
     ImGui::SameLineSeparator();
@@ -1300,10 +1301,18 @@ namespace dxvk {
     }
 
     ImGui::SetTooltipToLastWidgetOnHover("Screenshot will be dumped to, '<exe-dir>/Screenshots'");
-
+    const float FontScale = RtxOptions::menuFontScale();
     ImGui::SameLine(200.f);
     ImGui::Checkbox("Include G-Buffer", &RtxOptions::Get()->captureDebugImageObject());
-        
+    ImGui::DragFloat("Font Scale", &RtxOptions::Get()->menuFontScaleObject(), 0.25f, 0.3f, 2.f, "%.2f", sliderFlags);
+    /*
+    ImGui::SameLine(250.f);
+    if(ImGui::Button("Apply Font Changes")) {
+      //BUGBUG: This button will crash Remix. This is because ImGui cannot rebuild an existing font while rendering.  
+      //This change must happen between Render and NewFrame or instead using the PushFont / PopFont API.
+      ImGUI::createFontsTexture(ctx);
+    }
+    */
     { // Recompile Shaders button and its status message
       using namespace std::chrono;
       static enum { None, OK, Error } shaderMessage = None;
@@ -1332,7 +1341,7 @@ namespace dxvk {
         }
       }
     }
-    ImGui::SameLine(200.f);
+    ImGui::SameLine(200.f*FontScale);
     ImGui::Checkbox("Live shader edit mode", &RtxOptions::Get()->useLiveShaderEditModeObject());
 
     showVsyncOptions(false);
@@ -2981,7 +2990,7 @@ namespace dxvk {
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplVulkan_Data* bd = (ImGui_ImplVulkan_Data*)io.BackendRendererUserData;
     ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
-    
+    const float FontScale = RtxOptions::menuFontScale();
     // Range of characters we want to use the primary font
     ImVector<ImWchar> characterRange;
     {
@@ -3001,7 +3010,7 @@ namespace dxvk {
     // Normal Size Font (Default)
 
     ImFontConfig normalFontCfg = ImFontConfig();
-    normalFontCfg.SizePixels = 16.f;
+    normalFontCfg.SizePixels = 16.f * FontScale;
     normalFontCfg.FontDataOwnedByAtlas = false;
 
     const size_t nvidiaSansLength = sizeof(___NVIDIASansMd) / sizeof(___NVIDIASansMd[0]);
@@ -3021,7 +3030,7 @@ namespace dxvk {
     // Large Size Font
 
     ImFontConfig largeFontCfg = ImFontConfig();
-    largeFontCfg.SizePixels = 24.f;
+    largeFontCfg.SizePixels = 24.f * FontScale;
     largeFontCfg.FontDataOwnedByAtlas = false;
 
     {

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -246,6 +246,10 @@ namespace dxvk {
                "A float to set the scale of thumbnails while selecting textures.\n"
                "This will be scaled by the default value of 120 pixels.\n"
                "This value must always be greater than zero.");
+    RTX_OPTION("rtx.gui", float, menuFontScale, 1.f,
+               "A float to set the scale of text and fonts.\n"
+                "This will be scaled relative to the default font size in pixels.\n"
+               "This value should always be greater than 0.");
     RTX_OPTION("rtx", bool, skipDrawCallsPostRTXInjection, false, "Ignores all draw calls recorded after RTX Injection, the location of which varies but is currently based on when tagged UI textures begin to draw.");
     RTX_OPTION_ENV("rtx", DlssPreset, dlssPreset, DlssPreset::On, "RTX_DLSS_PRESET", "Combined DLSS Preset for quickly controlling Upscaling, Frame Interpolation and Latency Reduction.");
     RTX_OPTION("rtx", NisPreset, nisPreset, NisPreset::Balanced, "Adjusts NIS scaling factor, trades quality for performance.");


### PR DESCRIPTION
Some users requested the ability to scale the UI and after a brief investigation, it seems this may actually be doable.  Attached to this PR is two commits.  One can be ignored as it's purely for my own testing purposes.  The other is a commit that:
- Adds a new RTX Option for font scale
- Adds a slider to adjust said font scale option [placeholder]
- Multiplies the font size during font creation

This approach has some drawbacks.  
- At the moment the font scale adjustment requires a restart.  Attempting to create a new font during runtime results in a crash with the current implementation, which just repeats the font creation step from startup... but there may be better alternatives to refreshing the font.  I have some ideas for how to get around this but it'll take some investigation and testing.
- This has only been applied to fonts; I will also need to add the variable to various existing ImGui elements with hardcoded values (e.g. the Remix splash message).  I will be further investigating this over the next week to see about adding a more polished version of this option to the menus.  I would also like some advice on where a UI-specific setting should be placed as most options in the Remix menu either pertain to a specific tab/section or the game settings, not the menu settings.

![borderzone_llHEsV6qCi](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/55258193/857a5a9b-3201-44d5-a607-8474725de23c)
![borderzone_0NrqbagOx0](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/55258193/aa90e225-474b-4335-9de4-b06c8d75f98c)

