### PR TITLE
Split Texture Category List - Fixes and Improvements

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -1540,6 +1540,9 @@ namespace dxvk {
     namespace texture_popup {
       constexpr char POPUP_NAME[] = "rtx_texture_selection_popup";
 
+      bool lastOpenCategoryActive = false;
+      std::string lastOpenCategoryId = {};
+
       // need to keep a reference to a texture that was passed to 'open()',
       // as 'open()' is called only once, but popup needs to reference that texture throughout open-close
       std::shared_future<XXH64_hash_t> g_holdingTexture = {};
@@ -1621,7 +1624,7 @@ namespace dxvk {
     }
   } // anonymous namespace
 
-  void ImGUI::showTextureSelectionGrid(const Rc<DxvkContext>& ctx, const char* uniqueId, const uint32_t texturesPerRow, const float thumbnailSize) {
+  void ImGUI::showTextureSelectionGrid(const Rc<DxvkContext>& ctx, const char* uniqueId, const uint32_t texturesPerRow, const float thumbnailSize, const float minChildHeight) {
     ImGui::PushID(uniqueId);
     auto common = ctx->getCommonObjects();
     uint32_t cnt = 0;
@@ -1642,7 +1645,8 @@ namespace dxvk {
     }
 
     const ImVec2 availableSize = ImGui::GetContentRegionAvail();
-    const float childWindowHeight = availableSize.y < 600 ? 600 : availableSize.y;
+    const float childWindowHeight = minChildHeight <= 600.0f ? minChildHeight
+                                                             : availableSize.y < 600 ? 600.0f : availableSize.y;
     ImGuiWindowFlags window_flags = ImGuiWindowFlags_None;
     ImGui::BeginChild(str::format("Child", uniqueId).c_str(), ImVec2(availableSize.x, childWindowHeight), false, window_flags);
 
@@ -1667,7 +1671,17 @@ namespace dxvk {
           }
         }
       }
-      
+
+      if (legacyTextureGuiShowAssignedOnly()) {
+        if (std::string_view(uniqueId) != "textures") {
+          if (!textureHasSelection) {
+            continue; // Texture is not assigned to this category -> skip
+          }
+        } else if (textureHasSelection) {
+          continue; // Currently handling the uncategorized texture tab and current texture is assigned to a category -> skip
+        }
+      }
+
       if (texHash == nonBlockingGet(texture_popup::g_holdingTexture) || texHash == s_jumpto) {
         auto anim = Vector4 { 0.462745f, 0.725490f, 0.f, 1.f } * animatedHighlightIntensity(common->getSceneManager().getGameTimeSinceStartMS());
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(anim.r, anim.g, anim.b, anim.a));
@@ -1702,7 +1716,8 @@ namespace dxvk {
       ImGui::SetCursorPosY(y + (thumbnailSize - extent.y) / 2.f);
 
       if (ImGui::ImageButton(texImgui.texID, extent)) {
-        if (isListFiltered) {
+        // Legacy list = no popup // Legacy list + show assigned only = popup
+        if (isListFiltered && !legacyTextureGuiShowAssignedOnly()) {
           toggleTextureSelection(texHash, uniqueId, listRtxOption.textureSetOption->getValue());
         } else {
           clickedOnTextureButton = true;
@@ -1736,6 +1751,9 @@ namespace dxvk {
           if (ImGui::IsMouseReleased(ImGuiMouseButton_Middle)) {
             ImGui::SetClipboardText(hashToString(texHash).c_str());
           }
+          if (std::string_view(uniqueId) != texture_popup::lastOpenCategoryId) {
+            texture_popup::lastOpenCategoryId = uniqueId;
+          }
         }
       }
 
@@ -1750,11 +1768,12 @@ namespace dxvk {
       }
     }
 
-    // popup for texture selection from world / ui
-    {
+    // Popup for texture selection from world / ui
+    // Only the "active" category is allowed to control the texture popup and highlighting logic
+    if (std::string_view(uniqueId) == texture_popup::lastOpenCategoryId) {
       const bool wasUIClick = clickedOnTextureButton;
-      const bool wasWorldClick = !clickedOnTextureButton && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right));
-
+      const bool wasWorldClick = !clickedOnTextureButton && !ImGui::GetIO().WantCaptureMouse
+                                 && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right));
 
       auto foundTextureHashInFuture = std::future<XXH64_hash_t> {};
 
@@ -1776,30 +1795,37 @@ namespace dxvk {
         } else if (foundTextureHashInFuture.valid()) {
           texture_popup::open(std::move(foundTextureHashInFuture));
         }
+
+        texture_popup::lastOpenCategoryId = uniqueId;
       }
 
-      auto texHashToHighlight = std::optional<XXH64_hash_t>{};
+      {
+        auto texHashToHighlight = std::optional<XXH64_hash_t> {};
 
-      // top priority for what's inside a currently open texture popup
-      if (auto texInPopup = texture_popup::produce(common->getSceneManager())) {
-        texHashToHighlight = *texInPopup;
-      } else {
-        if (foundTextureHash) {
-          texHashToHighlight = *foundTextureHash;
-        } else if (auto ft = nonBlockingGet(foundTextureHashInFuture)) {
-          if (ft != kEmptyHash) {
-            texHashToHighlight = *ft;
+        // top priority for what's inside a currently open texture popup
+        if (auto texInPopup = texture_popup::produce(common->getSceneManager())) {
+          texHashToHighlight = *texInPopup;
+        } else {
+          if (foundTextureHash) {
+            texHashToHighlight = *foundTextureHash;
+          } else if (auto ft = nonBlockingGet(foundTextureHashInFuture)) {
+            if (ft != kEmptyHash) {
+              texHashToHighlight = *ft;
+            }
           }
         }
-      }
 
-      if (texHashToHighlight) {
-        common->getSceneManager().requestHighlighting(*texHashToHighlight, highlightColor, ctx->getDevice()->getCurrentFrameId());
-      }
+        if (texHashToHighlight) {
+          common->getSceneManager().requestHighlighting(*texHashToHighlight, highlightColor, ctx->getDevice()->getCurrentFrameId());
+        }
 
-      // on world texture, move UI menu focus
-      if (isWorldTextureSelectionEnabled() && texHashToHighlight) {
-        s_jumpto = *texHashToHighlight;
+        // on world texture, move UI menu focus
+        if (isWorldTextureSelectionEnabled() && texHashToHighlight) {
+          s_jumpto = *texHashToHighlight;
+        }
+
+        // checked after the last 'showTextureSelectionGrid' call to see if saved category is still active
+        texture_popup::lastOpenCategoryActive = true;
       }
     }
 
@@ -1856,6 +1882,8 @@ namespace dxvk {
   void ImGUI::showSetupWindow(const Rc<DxvkContext>& ctx) {
     ImGui::PushItemWidth(200);
 
+    texture_popup::lastOpenCategoryActive = false;
+
     const float thumbnailScale = RtxOptions::textureGridThumbnailScale();
     const float thumbnailSize = (120.f * thumbnailScale);
     const float thumbnailSpacing = ImGui::GetStyle().ItemSpacing.x;
@@ -1866,6 +1894,11 @@ namespace dxvk {
 
     if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Step 1: Categorize Textures", collapsingHeaderClosedFlags), "Select texture definitions for Remix")) {
       ImGui::Checkbox("Split Texture Category List", &showLegacyTextureGuiObject());
+
+      if (showLegacyTextureGui()) {
+        ImGui::Checkbox("Only Show Assigned Textures in Category Lists", &legacyTextureGuiShowAssignedOnlyObject());
+      }
+
       ImGui::DragFloat("Texture Thumbnail Scale", &RtxOptions::Get()->textureGridThumbnailScaleObject(), 0.25f, 0.25f, 3.f, "%.2f", sliderFlags);
       ImGui::Separator();
 
@@ -1877,148 +1910,172 @@ namespace dxvk {
         showTextureSelectionGrid(ctx, "textures", numThumbnailsPerRow, thumbnailSize);
       }
       else {
+        // Wrapper function that controls childheight and logic specific to 'showTextureSelectionGrid'
+        const auto& showTextureSelectionGridWrapper = [&](const char* uniqueId) {
+          const bool isUncategorized = std::string_view(uniqueId) == "textures";
+          float childHeight = 600.0f;
+          uint32_t textureCount = 0;
+          uint32_t rowCount = 1;
+
+          // Count textures that are assigned to the current category to calculate childheight for ImGui::BeginChild in 'showTextureSelectionGrid'
+          if (legacyTextureGuiShowAssignedOnly() && !isUncategorized) {
+            RtxTextureOption listRtxOption;
+
+            for (auto rtxOption : rtxTextureOptions) {
+              if (strcmp(rtxOption.uniqueId, uniqueId) == 0) {
+                listRtxOption = rtxOption;
+                break;
+              }
+            }
+
+            for (auto& [texHash, texImgui] : g_imguiTextureMap) {
+              auto& textureSet = listRtxOption.textureSetOption->getValue();
+              bool textureHasSelection = textureSet.find(texHash) != textureSet.end();
+
+              if (!textureHasSelection) {
+                continue;
+              }
+
+              textureCount++;
+
+              if (textureCount > numThumbnailsPerRow * rowCount) {
+                rowCount++;
+              }
+
+              childHeight = static_cast<float>(rowCount) * thumbnailSize + 16.0f;
+
+              if (childHeight >= 600.0f) {
+                break;
+              }
+            }
+          }
+
+          if (textureCount || isUncategorized || !legacyTextureGuiShowAssignedOnly()) {
+            if (ImGui::IsItemToggledOpen() || texture_popup::lastOpenCategoryId.empty()) {
+              // Update last opened category ID if texture category (ImGui::CollapsingHeader) was just toggled open or if ID is empty
+              texture_popup::lastOpenCategoryId = uniqueId;
+            }
+
+            ImGui::Unindent();
+            showTextureSelectionGrid(ctx, uniqueId, numThumbnailsPerRow, thumbnailSize, childHeight);
+            ImGui::Indent();
+          }
+          else {
+            ImGui::Spacing();
+            ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize("Empty").x) * 0.5f);
+            ImGui::Text("Empty");
+            ImGui::Spacing();
+          }
+        };
+
         ImGui::Indent();
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("UI Textures", collapsingHeaderClosedFlags), RtxOptions::Get()->uiTexturesDescription())) {
           //Legacy GUI: Using indents in this field is causing issues with padding where the rightmost texture is cut off by the scroll bar.
           //Unindent and indent around each list to preserve formatting and use full space while keeping headers and other UI indented for organization.
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "uitextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("uitextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Worldspace UI Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->worldSpaceUiTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "worldspaceuitextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("worldspaceuitextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Worldspace UI Background Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->worldSpaceUiBackgroundTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "worldspaceuibackgroundtextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("worldspaceuibackgroundtextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Sky Textures", collapsingHeaderClosedFlags), RtxOptions::Get()->skyBoxTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "skytextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("skytextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Ignore Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->ignoreTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "ignoretextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("ignoretextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Hide Instance Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->hideInstanceTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "hidetextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("hidetextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Lightmap Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->lightmapTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "lightmaptextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("lightmaptextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Ignore Lights (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->ignoreLightsDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "ignorelights", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("ignorelights");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Particle Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->particleTexturesDescription())) {
-          ImGui::Unindent(); 
-          showTextureSelectionGrid(ctx, "particletextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("particletextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Beam Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->beamTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "beamtextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("beamtextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Add Lights to Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->lightConverterDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "lightconvertertextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("lightconvertertextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Decal Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->decalTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "decaltextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("decaltextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Dynamic Decal Textures", collapsingHeaderClosedFlags), RtxOptions::Get()->dynamicDecalTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "dynamicdecaltextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("dynamicdecaltextures");
         }
         
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Single Offset Decal Textures", collapsingHeaderClosedFlags), RtxOptions::Get()->singleOffsetDecalTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "singleoffsetdecaltextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("singleoffsetdecaltextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Non-Offset Decal Textures", collapsingHeaderClosedFlags), RtxOptions::Get()->nonOffsetDecalTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "nonoffsetdecaltextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("nonoffsetdecaltextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Legacy Cutout Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->cutoutTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "cutouttextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("cutouttextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Terrain Textures", collapsingHeaderClosedFlags), RtxOptions::Get()->terrainTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "terraintextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("terraintextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Water Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->animatedWaterTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "watertextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent(); 
+          showTextureSelectionGridWrapper("watertextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Player Model Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->playerModelTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "playermodeltextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent(); 
+          showTextureSelectionGridWrapper("playermodeltextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Player Model Body Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->playerModelBodyTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "playermodelbodytextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("playermodelbodytextures");
         }
 
         if (RtxOptions::AntiCulling::Object::enable() &&
           IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Anti-Culling Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->antiCullingTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "antiCullingTextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("antiCullingTextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Motion Blur Mask-Out Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->motionBlurMaskOutTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "motionBlurMaskOutTextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent(); 
+          showTextureSelectionGridWrapper("motionBlurMaskOutTextures");
         }
 
         if (IMGUI_ADD_TOOLTIP(ImGui::CollapsingHeader("Opacity Micromap Ignore Textures (optional)", collapsingHeaderClosedFlags), RtxOptions::Get()->opacityMicromapIgnoreTexturesDescription())) {
-          ImGui::Unindent();
-          showTextureSelectionGrid(ctx, "opacitymicromapignoretextures", numThumbnailsPerRow, thumbnailSize);
-          ImGui::Indent();
+          showTextureSelectionGridWrapper("opacitymicromapignoretextures");
+        }
+
+        if (legacyTextureGuiShowAssignedOnly())
+        {
+          if (ImGui::CollapsingHeader("Uncategorized", collapsingHeaderClosedFlags)) {
+            showTextureSelectionGridWrapper("textures");
+          }
         }
         ImGui::Unindent();
+
+        // Check if last saved category was closed this frame
+        if (!texture_popup::lastOpenCategoryActive) {
+          texture_popup::lastOpenCategoryId.clear();
+        }
       }
     }
 

--- a/src/dxvk/imgui/dxvk_imgui.h
+++ b/src/dxvk/imgui/dxvk_imgui.h
@@ -207,7 +207,7 @@ namespace dxvk {
     void showAppConfig(const Rc<DxvkContext>& ctx);
 
     // helper to display a configurable grid of all textures currently hooked to ImGUI
-    void showTextureSelectionGrid(const Rc<DxvkContext>& ctx, const char* uniqueId, const uint32_t texturesPerRow, const float thumbnailSize);
+    void showTextureSelectionGrid(const Rc<DxvkContext>& ctx, const char* uniqueId, const uint32_t texturesPerRow, const float thumbnailSize, const float minChildHeight = 600.0f);
 
     void createFontsTexture(const Rc<DxvkContext>& ctx);
 
@@ -221,6 +221,7 @@ namespace dxvk {
     void showMemoryStats() const;
 
     RTX_OPTION("rtx.gui", bool, showLegacyTextureGui, false, "A setting to toggle the old texture selection GUI, where each texture category is represented as its own list.");
+    RTX_OPTION("rtx.gui", bool, legacyTextureGuiShowAssignedOnly, false, "A setting to show only the textures in a category that are assigned to it (Unassigned textures are found in the \"Uncategorized\" list at the bottom).");
     RTX_OPTION("rtx.gui", float, reflexStatRangeInterpolationRate, 0.05f, "A value controlling the interpolation rate applied to the Reflex stat graph ranges for smoother visualization.");
     RTX_OPTION("rtx.gui", float, reflexStatRangePaddingRatio, 0.05f, "A value specifying the amount of padding applied to the Reflex stat graph ranges as a ratio to the calculated range.");
   

--- a/src/dxvk/imgui/dxvk_imgui_about.cpp
+++ b/src/dxvk/imgui/dxvk_imgui_about.cpp
@@ -91,7 +91,8 @@ namespace dxvk {
   ImGuiAbout::Credits::Credits()
     : m_sections({
       { "Github Contributors",
-        { "Leonardo Leotte",
+        { "Alexander 'xoxor4d' Engel",
+          "Leonardo Leotte",
           "Nico Rodrigues-McKenna"}},
       { "Engineering",
         { "Riley Alston",


### PR DESCRIPTION
This pull request fixes a few issues related to the legacy (split) texture list and also adds a new toggleable setting that only shows textures in a category that are assigned to that category. 
Unassigned textures will be displayed in a new list called "Uncategorized".


### Why?
Categorizing textures in games with a huge amount of loaded textures can get pretty painful. Especially if the list you are working with does not shrink in size.
It can also get really tedious to find textures you once assigned to a category if that category turned out to be wrong. 
Having scrolled hundreds of textures to only get your scrolling position changed by accidentally moving your mouse over the world made me think about creating this :D


### Issues with the legacy list prior to this pull request:
1. Having 2 or more category lists open and clicking a texture would not open the category-assignment popup and just leave a little dark square at sometimes random places. Same applies to "world" clicks.
2. IIRC, in earlier versions of remix, having the "Split Texture Category List" setting enabled would not show the category-assignment popup and just assign the texture one clicked on to the category it was clicked in. This is no longer the case and it will always show the popup. That behaviour doesn't make much sense to me if each list shows every texture.


Changes to fix issue 1:
- Add string `lastOpenCategoryId` to the `texture_popup` namespace. _lastOpenCategoryId_ holds the uniqueId of the currently active category (either by opening it or by hovering a texture within it). _lastOpenCategoryId_ is checked within function `showTextureSelectionGrid` so that only the active category that called _showTextureSelectionGrid_ is allowed to use its embedded texture highlighting / texture assignment popup logic.  
- Add bool `lastOpenCategoryActive` to the `texture_popup` namespace. It is used to check if the category saved in _lastOpenCategoryId_ remained the active category (after all subsequent _showTextureSelectionGrid_ function calls).
Mainly used it to check if a category header was closed. It will then clear the `lastOpenCategoryId` string and logic within either `showSetupWindow` or `showTextureSelectionGrid` assigns a new active category within the next frame.

<br>

```cpp
const bool wasWorldClick = !clickedOnTextureButton && !ImGui::GetIO().WantCaptureMouse 
          && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right));
```
- Add `!WantCaptureMouse` check because `wasWorldClick` is true when clicking anywhere within the GUI that is not a texture. (Not really related to any issue anymore)


Changes to fix issue 2:
- Fixing issue 1 also fixed issue 2 so the legacy split texture list no longer opens a popup and instead adds or removes the category directly upon clicking the texture

---

### TL;DR
- Add a new toggle called `Only Show Assigned Textures in Category Lists` under `Split Texture Category List` that is only visible if split view is enabled
![remix-pr-01](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/45299104/cfc0c933-f646-4274-a636-32840fe1b0a1)

- Categories will now only show the textures that are assigned to it
![image](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/45299104/a9021404-ba03-4e47-8a05-4814494f7fc0)

- Also adds a new list at the bottom of the existing categories called `Uncategorized` where all textures with no assignments can be found
![remix-pr-04](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/45299104/173ee964-39cf-4ced-adfe-a48a45605a33)


