### PR TITLE
Bump version of github checkout actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         script: core.exportVariable('GITHUB_SHA_SHORT', context.sha.substring(0, 7))
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 


### PR DESCRIPTION
Bump version of github checkout actions to address upcoming deprecation of Node.js 16 in older github action nodes:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/