### PR TITLE
Configurable effect light color

### DIFF
--- a/src/dxvk/rtx_render/rtx_scene_manager.cpp
+++ b/src/dxvk/rtx_render/rtx_scene_manager.cpp
@@ -585,7 +585,7 @@ namespace dxvk {
     }
   }
 
-  void SceneManager::createEffectLight(Rc<DxvkContext> ctx, const DrawCallState& input, const RtInstance* instance) {
+  void SceneManager::createEffectLight(Rc<DxvkContext> ctx, const DrawCallState& input, const RtInstance* instance, const MaterialData& renderMaterialData) {
     const float effectLightIntensity = RtxOptions::Get()->getEffectLightIntensity();
     if (effectLightIntensity <= 0.f)
       return;
@@ -631,8 +631,8 @@ namespace dxvk {
       const double animationPhase = sin(timeMilliseconds * 0.006) * 0.5 + 0.5;
       lightRadiance = lerp(Vector3(1.f, 0.921f, 0.738f), Vector3(1.f, 0.521f, 0.238f), animationPhase) * radianceFactor;
     } else {
-      const D3DCOLORVALUE originalColor = input.getMaterialData().getLegacyMaterial().Diffuse;
-      lightRadiance = Vector3(originalColor.r, originalColor.g, originalColor.b) * radianceFactor;
+      const Vector3 albedoConstant = renderMaterialData.getOpaqueMaterialData().getAlbedoConstant();
+      lightRadiance = albedoConstant * radianceFactor;
     }
 
     RtLight rtLight(RtSphereLight(lightPosition, lightRadiance, lightRadius, shaping));
@@ -1102,7 +1102,7 @@ namespace dxvk {
 
     // Check if a light should be created for this Material
     if (instance && RtxOptions::Get()->shouldConvertToLight(drawCallState.getMaterialData().getHash())) {
-      createEffectLight(ctx, drawCallState, instance);
+      createEffectLight(ctx, drawCallState, instance, renderMaterialData);
     }
 
     const bool objectPickingActive = m_device->getCommon()->getResources().getRaytracingOutput()

--- a/src/dxvk/rtx_render/rtx_scene_manager.h
+++ b/src/dxvk/rtx_render/rtx_scene_manager.h
@@ -251,7 +251,7 @@ private:
 
   uint64_t drawReplacements(Rc<DxvkContext> ctx, const DrawCallState* input, const std::vector<AssetReplacement>* pReplacements, const MaterialData* overrideMaterialData);
 
-  void createEffectLight(Rc<DxvkContext> ctx, const DrawCallState& input, const RtInstance* instance);
+  void createEffectLight(Rc<DxvkContext> ctx, const DrawCallState& input, const RtInstance* instance, const MaterialData& renderMaterialData);
 
   uint32_t m_beginUsdExportFrameNum = -1;
   bool m_enqueueDelayedClear = false;


### PR DESCRIPTION
This was Mark's suggestion for a quick solution.
The effect light radiance is set to the replacement material's albedo color.

If the material has no replacements, its radiance will be 0 thus it is waste. An early return could be used to prevent this.
![resim](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/84380947/468cb4ed-96ba-4345-af8c-282a39ee6a51)

The replacement opacity material still has the albedo color set close to 1 by default, while it is red for translucents -for some reason-?
![resim](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/84380947/cba02246-be93-4cc6-827d-54d82c16eb73)

This is especially useful since we use effect lights for things without stable anchors like muzzle flashes or projectiles which the white light is really limiting and doesn't make much sense.

The portal plasma ball (`rtx.effectLightPlasmaBall = True`) is unaffected.