### PR TITLE
Add option to configure the scene world space coordinate system

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -2087,6 +2087,7 @@ namespace dxvk {
       spacing();
       ImGui::DragFloat("Scene Unit Scale", &RtxOptions::Get()->sceneScaleObject(), 0.00001f, 0.00001f, FLT_MAX, "%.3f", sliderFlags);
       ImGui::Checkbox("Scene Z-Up", &RtxOptions::Get()->zUpObject());
+      ImGui::Checkbox("Scene Left-Handed Coordinate System", &RtxOptions::Get()->leftHandedCoordinateSystemObject());
       fusedWorldViewModeCombo.getKey(&RtxOptions::Get()->fusedWorldViewModeRef());
       ImGui::Separator();
 

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -357,6 +357,7 @@ namespace dxvk {
     RTX_OPTION("rtx", bool, enableDirectLighting, true, "Enables direct lighting (lighting directly from lights on to a surface) on surfaces when set to true, otherwise disables it.");
     RTX_OPTION("rtx", bool, enableSecondaryBounces, true, "Enables indirect lighting (lighting from diffuse/specular bounces to one or more other surfaces) on surfaces when set to true, otherwise disables it.");
     RTX_OPTION("rtx", bool, zUp, false, "Indicates that the Z axis is the \"upward\" axis in the world when true, otherwise the Y axis when false.");
+    RTX_OPTION("rtx", bool, leftHandedCoordinateSystem, false, "Indicates that the world space coordinate system is left-handed when true, otherwise right-handed when false.");
     RTX_OPTION("rtx", float, uniqueObjectDistance, 300.f, "The distance (in game units) that an object can move in a single frame before it is no longer considered the same object.\n"
                     "If this is too low, fast moving objects may flicker and have bad lighting.  If it's too high, repeated objects may flicker.\n"
                     "This does not account for sceneScale.");
@@ -1213,6 +1214,7 @@ namespace dxvk {
     bool shouldCaptureDebugImage() const { return captureDebugImage(); }
     bool isLiveShaderEditModeEnabled() const { return useLiveShaderEditMode(); }
     bool isZUp() const { return zUp(); }
+    bool isLeftHandedCoordinateSystem() const { return leftHandedCoordinateSystem(); }
     float getUniqueObjectDistanceSqr() const { return uniqueObjectDistance() * uniqueObjectDistance(); }
     float getResolutionScale() const { return resolutionScale(); }
     DLSSProfile getDLSSQuality() const { return qualityDLSS(); }

--- a/src/dxvk/rtx_render/rtx_scene_manager.cpp
+++ b/src/dxvk/rtx_render/rtx_scene_manager.cpp
@@ -131,7 +131,9 @@ namespace dxvk {
   }
 
   Vector3 SceneManager::calculateSceneRight() {
-    return cross(getSceneForward(), getSceneUp());
+    const Vector3 up = SceneManager::getSceneUp();
+    const Vector3 forward = SceneManager::getSceneForward();
+    return RtxOptions::Get()->isLeftHandedCoordinateSystem() ? cross(up, forward) : cross(forward, up);
   }
 
   Vector3 SceneManager::worldToSceneOrientedVector(const Vector3& worldVector) {


### PR DESCRIPTION
## Description

Fixes https://github.com/NVIDIAGameWorks/rtx-remix/issues/432.

`SceneManager::calculateSceneRight()` assumed a right-handed coordinate system, which meant it computed the wrong value for games using a left-handed coordinate system.

This change adds an option `leftHandedCoordinateSystem` which makes the world space coordinate system configurable. I have exposed this option on the developer GUI alongside the `zUp` option.

## Testing

Tested in Star Wars Galaxies which uses a left-handed coordinate system. The terrain baking previously failed due to the incorrect value computed by `SceneManager::calculateSceneRight()`:

![image](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/5884019/50cfe6df-e1f5-4ebe-99ff-d039ce12d7b3)

Now works with the option enabled:

![image](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/5884019/77637bf4-126b-40c6-9cf4-2d31f2266ceb)

