### PR TITLE
options: Default to RT pipelines on RADV

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui_about.cpp
+++ b/src/dxvk/imgui/dxvk_imgui_about.cpp
@@ -96,6 +96,7 @@ namespace dxvk {
           "Nico Rodrigues-McKenna",
           "James 'jdswebb' Webb",
           "James Horsley 'mmdanggg2'",
+          "Friedrich 'pixelcluster' Vock",
       }},
       { "Engineering",
         { "Riley Alston",

--- a/src/dxvk/rtx_render/rtx_initializer.cpp
+++ b/src/dxvk/rtx_render/rtx_initializer.cpp
@@ -59,7 +59,7 @@ namespace dxvk {
 
       RtxOptions::Get()->updateUpscalerFromDlssPreset();
       RtxOptions::Get()->updateGraphicsPresets(m_device);
-      RtxOptions::Get()->updateRaytraceModePresets(deviceInfo.core.properties.vendorID);
+      RtxOptions::Get()->updateRaytraceModePresets(deviceInfo.core.properties.vendorID, deviceInfo.khrDeviceDriverProperties.driverID);
     } else {
       // Default, init to custom unless otherwise specified
       if (RtxOptions::Get()->graphicsPreset() == GraphicsPreset::Auto)

--- a/src/dxvk/rtx_render/rtx_options.cpp
+++ b/src/dxvk/rtx_render/rtx_options.cpp
@@ -296,7 +296,7 @@ namespace dxvk {
     forceHighResolutionReplacementTexturesRef() = false;
   }
 
-  void RtxOptions::updateRaytraceModePresets(const uint32_t vendorID) {
+  void RtxOptions::updateRaytraceModePresets(const uint32_t vendorID, const VkDriverId driverID) {
     // Handle Automatic Raytrace Mode Preset (From configuration/default)
 
     if (RtxOptions::Get()->raytraceModePreset() == RaytraceModePreset::Auto) {
@@ -307,9 +307,12 @@ namespace dxvk {
       DxvkPathtracerIntegrateDirect::RaytraceMode preferredIntegrateDirectRaytraceMode;
       DxvkPathtracerIntegrateIndirect::RaytraceMode preferredIntegrateIndirectRaytraceMode;
 
-      if (vendorID == static_cast<uint32_t>(DxvkGpuVendor::Nvidia)) {
-        // Default to a mixture of Trace Ray and Ray Query on NVIDIA
-        Logger::info("NVIDIA architecture detected, setting default raytrace modes to Trace Ray (GBuffer/Indirect Integrate) and Ray Query (Direct Integrate)");
+      if (vendorID == static_cast<uint32_t>(DxvkGpuVendor::Nvidia) || driverID == VK_DRIVER_ID_MESA_RADV) {
+        // Default to a mixture of Trace Ray and Ray Query on NVIDIA and RADV
+	     if (driverID == VK_DRIVER_ID_MESA_RADV)
+          Logger::info("RADV detected, setting default raytrace modes to Trace Ray (GBuffer/Indirect Integrate) and Ray Query (Direct Integrate)");
+	     else
+          Logger::info("NVIDIA architecture detected, setting default raytrace modes to Trace Ray (GBuffer/Indirect Integrate) and Ray Query (Direct Integrate)");
 
         preferredGBufferRaytraceMode = DxvkPathtracerGbuffer::RaytraceMode::TraceRay;
         preferredIntegrateDirectRaytraceMode = DxvkPathtracerIntegrateDirect::RaytraceMode::RayQuery;

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -1159,7 +1159,7 @@ namespace dxvk {
     NV_GPU_ARCHITECTURE_ID getNvidiaArch();
     NV_GPU_ARCH_IMPLEMENTATION_ID getNvidiaChipId();
     void updateGraphicsPresets(const DxvkDevice* device);
-    void updateRaytraceModePresets(const uint32_t vendorID);
+    void updateRaytraceModePresets(const uint32_t vendorID, const VkDriverId driverID);
 
     void resetUpscaler();
 


### PR DESCRIPTION
This roughly triples performance in Portal RTX with RADV from my testing using dxvk.conf overrides.

Note that because this fork's build system isn't compatible with Linux anymore, I haven't been able to build/test this properly. It's not a very complex change though, so it should work.