### PR TITLE
Use AABB to better differentiate instances

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -2108,6 +2108,7 @@ namespace dxvk {
         ImGui::Indent();
         ImGui::Checkbox("Orthographic Is UI", &D3D9Rtx::orthographicIsUIObject());
         ImGui::Checkbox("Allow Cubemaps", &D3D9Rtx::allowCubemapsObject());
+        ImGui::Checkbox("AABB's For Instance Differentiation", &RtxOptions::Get()->instanceUseBoundingBoxObject());
         ImGui::Unindent();
       }
 

--- a/src/dxvk/rtx_render/rtx_draw_call_cache.cpp
+++ b/src/dxvk/rtx_render/rtx_draw_call_cache.cpp
@@ -85,7 +85,8 @@ DrawCallCache::CacheState DrawCallCache::get(const DrawCallState& drawCall, Blas
 
   float bestScore = std::numeric_limits<float>::min();
   Matrix4 newTransform = drawCall.getTransformData().objectToWorld;
-  const Vector3 newWorldPosition = Vector3(newTransform[3][0], newTransform[3][1], newTransform[3][2]);
+  const Vector3 newWorldPosition = drawCall.getGeometryData().boundingBox.getTransformedCentroid(newTransform);
+
   for (auto bucketIter = range.first; bucketIter != range.second; bucketIter++) {
     BlasEntry& blas  = bucketIter->second;
     if (exactMatch(drawCall, blas)) {
@@ -110,7 +111,7 @@ DrawCallCache::CacheState DrawCallCache::get(const DrawCallState& drawCall, Blas
     // TODO this is only checking the distance to the first instance that created the BlasEntry, not to
     // each instance.  It also doesn't include the portal logic from InstanceManager.
     Matrix4 oldTransform = blas.input.getTransformData().objectToWorld;
-    const Vector3 worldPosition = Vector3(oldTransform[3][0], oldTransform[3][1], oldTransform[3][2]);
+    const Vector3 worldPosition = blas.input.getGeometryData().boundingBox.getTransformedCentroid(oldTransform);
     score -= lengthSqr(newWorldPosition - worldPosition);
     if (score > bestScore) {
       bestScore = score;

--- a/src/dxvk/rtx_render/rtx_options.cpp
+++ b/src/dxvk/rtx_render/rtx_options.cpp
@@ -341,6 +341,7 @@ namespace dxvk {
   bool RtxOptions::needsMeshBoundingBox() {
     return AntiCulling::Object::enable() ||
            AntiCulling::Light::enable()  ||
-           TerrainBaker::needsTerrainBaking();
+           TerrainBaker::needsTerrainBaking() ||
+           instanceUseBoundingBox();
   }
 }

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -333,6 +333,8 @@ namespace dxvk {
     RTX_OPTION("rtx", uint32_t, minPrimsInStaticBLAS, 1000, "");
     RTX_OPTION("rtx", uint32_t, maxPrimsInMergedBLAS, 50000, "");
 
+    RTX_OPTION("rtx", bool, instanceUseBoundingBox, false, "Use AABB's to better differentiate instances");
+
     // Camera
     RW_RTX_OPTION_ENV("rtx", bool, shakeCamera, false, "RTX_FREE_CAMERA_ENABLE_ANIMATION", "Enables animation of the free camera.");
     RTX_OPTION_ENV("rtx", CameraAnimationMode, cameraAnimationMode, CameraAnimationMode::CameraShake_Pitch, "RTX_FREE_CAMERA_ANIMATION_MODE", "Free camera's animation mode.");

--- a/src/dxvk/rtx_render/rtx_types.h
+++ b/src/dxvk/rtx_render/rtx_types.h
@@ -133,6 +133,19 @@ struct AxisAlignedBoundingBox {
     }
   }
 
+  Vector3 getCentroid() const {
+    return (minPos + maxPos) * 0.5f;
+  }
+
+  // returns untransformed position if AABB is invalid
+  Vector3 getTransformedCentroid(const Matrix4& transform) const {
+    if (isValid()) {
+      return (transform * Vector4(getCentroid(), 1.0f)).xyz();
+    } else {
+      return transform[3].xyz();
+    }
+  }
+
   const XXH64_hash_t calculateHash() const {
     return XXH3_64bits(this, sizeof(AxisAlignedBoundingBox));
   }


### PR DESCRIPTION
The changes in this PR try to improve instance matching by using its AABB instead of just its world position. 
This leads to more stable instances and thus in less visual artifacting -> motionblur smearing. 
I think these changes can also help with switching LOD's.

The changes in action (on/off and tweaked `Unique Object Search Distance` - Call of Duty 4 SP):
https://drive.google.com/file/d/1MtYsdSmAw1HzKZhbvBP7VUlRBRjkEte2

I've started working on this because of the issue I've opened here: https://github.com/NVIDIAGameWorks/rtx-remix/issues/450
Thanks to Alex for all the guidance (and previously Mark on discord)!

### Changes

- add `Vector3 getCentroid()` to `AxisAlignedBoundingBox`
- use transformed bounding-box-centroid instead of world position of the instance in `InstanceManager::findSimilarInstance`
- ^ in `RtInstance::onTransformChanged`
- ^ in `RtInstance::teleport`
- ^ in `DrawCallCache::get`
- add `AABB's For Instance Differentiation` setting to the Heuristics tab
- add setting check to `RtxOptions::needsMeshBoundingBox` to enable boundingbox calculations

The initial branch with the individual commits leading up to this squished commit is still available:
https://github.com/xoxor4d/dxvk-remix/commits/feature/aabb_inst