### PR TITLE
fix wrong imgui label under froxel radiance cache

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -2676,7 +2676,7 @@ namespace dxvk {
         ImGui::DragInt("Min Kernel Radius", &RtxOptions::Get()->froxelMinKernelRadiusObject(), 0.05f, 1, UINT8_MAX);
         ImGui::DragInt("Max Kernel Radius", &RtxOptions::Get()->froxelMaxKernelRadiusObject(), 0.05f, 1, UINT8_MAX);
         ImGui::DragInt("Min Kernel Radius Stability History", &RtxOptions::Get()->froxelMinKernelRadiusStabilityHistoryObject(), 0.1f, 1, UINT8_MAX);
-        ImGui::DragInt("Min Kernel Radius Stability History", &RtxOptions::Get()->froxelMaxKernelRadiusStabilityHistoryObject(), 0.1f, 1, UINT8_MAX);
+        ImGui::DragInt("Max Kernel Radius Stability History", &RtxOptions::Get()->froxelMaxKernelRadiusStabilityHistoryObject(), 0.1f, 1, UINT8_MAX);
         ImGui::DragFloat("Kernel Radius Stability History Power", &RtxOptions::Get()->froxelKernelRadiusStabilityHistoryPowerObject(), 0.01f, 0.0f, FLT_MAX, "%.2f", sliderFlags);
 
         ImGui::Unindent();


### PR DESCRIPTION
This fixes the wrong label for `Max Kernel Radius Stability History` (currently `Min Kernel ...`)  
under `Rendering > Froxel Radiance Cache/Volumetrics`. 

Currently:
![image](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/45299104/5343be6c-ba63-4474-9649-ac10af5037d4)

Editing one of the two affects the other one because Dear ImGui differentiates widgets using hashes calculated using the widget label.
![image](https://github.com/NVIDIAGameWorks/dxvk-remix/assets/45299104/0ee75bde-b495-4543-984e-a9eca3dd3e1a)
