### PR TITLE
Use a precompiled header in dxvk and d3d9 subprojects

### DIFF
--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -91,6 +91,10 @@ d3d9_src = [
   'd3d9_swapchain_external.cpp',
 ]
 
+d3d9_pch = [
+  'pch/d3d9_pch.h',
+]
+
 d3d9_dll = shared_library('d3d9', d3d9_src, dxvk_version, glsl_generator.process(d3d9_shaders), d3d9_res,
   name_prefix         : '',
   link_with           : [ util_lib ],
@@ -99,7 +103,8 @@ d3d9_dll = shared_library('d3d9', d3d9_src, dxvk_version, glsl_generator.process
   install             : true,
   objects             : not dxvk_is_msvc ? 'd3d9' + def_spec_ext : [],
   vs_module_defs      : 'd3d9'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  cpp_pch             : d3d9_pch)
 
 d3d9_dep = declare_dependency(
   link_with           : [ d3d9_dll ],

--- a/src/d3d9/pch/d3d9_pch.h
+++ b/src/d3d9/pch/d3d9_pch.h
@@ -1,0 +1,1 @@
+#include "../dxvk/dxvk_device.h"

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -367,6 +367,10 @@ dxvk_src = files([
   'imgui/implot_items.cpp',
 ])
 
+dxvk_pch = [
+  'pch/dxvk_pch.h',
+]
+
 thread_dep = dependency('threads')
 
 nrd_include_dir = include_directories(join_paths('../../', 'external/nrd/Include'))
@@ -434,7 +438,8 @@ dxvk_lib = static_library('dxvk', dxvk_src, dxvk_version, [generated_dxvk_shader
   link_with           : [ util_lib, spirv_lib ], 
   dependencies        : [ dxvk_deps ],
   include_directories : [ dxvk_include_path, dxvk_shader_include_path, rtxdi_include_path, remix_api_include_path ],
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  cpp_pch             : dxvk_pch)
 
 dxvk_dep = declare_dependency(
   link_with           : [ dxvk_lib ],

--- a/src/dxvk/pch/dxvk_pch.h
+++ b/src/dxvk/pch/dxvk_pch.h
@@ -1,0 +1,1 @@
+#include "dxvk_device.h"

--- a/src/dxvk/rtx_render/rtx_ngx_wrapper.cpp
+++ b/src/dxvk/rtx_render/rtx_ngx_wrapper.cpp
@@ -20,10 +20,12 @@
 * DEALINGS IN THE SOFTWARE.
 */
 
+#ifndef _WIN32_WINNT
 #define WIN32_NO_STATUS
 #include <windows.h>
 #undef WIN32_NO_STATUS
 #include <ntstatus.h>
+#endif
 #include <Winternl.h>
 #include <d3dkmthk.h>
 #include <d3dkmdt.h>


### PR DESCRIPTION
Preface: Shoving `dxvk_device.h` into a precompiled header is my last-ditch effort to get Visual Studio's intellisense working properly. I do not expect this PR to be merged as-is, if at all. These are just my observations since I figured it'd be worth investigating and maybe worth some input.

Pros:
- In my opinion, intellisense now works to an acceptable degree.
- Fresh builds using `build_dxvk_all_ninja.ps1` are reduced from 11 minutes to roughly 4 minutes (local machine).
- Fresh release builds using the VS solution are reduced from 4 minutes to roughly 1 minute (local machine).

Cons:
- Intellisense still occasionally trips up and freezes when opening many files.
- Virtually no benefits with incremental builds.
- Implicit includes are fragile in the long run and obfuscate real dependencies. The changes in `rtx_ngx_wrapper.cpp` are one example of this.
- Changes to `dxvk_device.h` and dependent headers are amplified. It's now part of ~200 translation units, up from ~100.

It seems like a combination of transitive USD includes and hundreds of macros/templates in remix cause intellisense to break down. Death by a thousand cuts with no simple fix.