### PR TITLE
Usage of two unused render states for special game scenarios (force material hash and texture categories)

### DIFF
--- a/src/d3d9/d3d9_rtx.cpp
+++ b/src/d3d9/d3d9_rtx.cpp
@@ -651,6 +651,11 @@ namespace dxvk {
     // Hash material data
     m_activeDrawCallState.materialData.updateCachedHash();
 
+    // Custom hash set via unused D3D RenderState
+    if (m_activeDrawCallState.materialData.remixHashFromD3D) {
+      m_activeDrawCallState.materialData.setHashOverride(m_activeDrawCallState.materialData.remixHashFromD3D);
+    }
+
     // For shader based drawcalls we also want to capture the vertex shader output
     const bool needVertexCapture = m_parent->UseProgrammableVS() && useVertexCapture();
     if (needVertexCapture) {

--- a/src/d3d9/d3d9_rtx_utils.cpp
+++ b/src/d3d9/d3d9_rtx_utils.cpp
@@ -176,6 +176,11 @@ namespace dxvk {
 
     materialData.alphaBlendEnabled = d3d9State.renderStates[D3DRS_ALPHABLENDENABLE] != FALSE;
 
+    if (RtxOptions::Get()->useUnusedRenderstates()) {
+      materialData.remixTextureCategoryFlagsFromD3D = d3d9State.renderStates[42] != 0xfefefefe ? d3d9State.renderStates[42] : 0u; // D3DRENDERSTATETYPE index 42 is not in use - unused values are set to 0xfefefefe
+      materialData.remixHashFromD3D = d3d9State.renderStates[150] != 0xfefefefe ? d3d9State.renderStates[150] : 0u; // D3DRENDERSTATETYPE index 150 is not in use - unused values are set to 0xfefefefe
+    }
+
     if (materialData.alphaBlendEnabled) {
       D3D9BlendState color;
       color.Src = D3DBLEND(d3d9State.renderStates[D3DRS_SRCBLEND]);

--- a/src/dxvk/rtx_render/rtx_materials.h
+++ b/src/dxvk/rtx_render/rtx_materials.h
@@ -1451,6 +1451,8 @@ struct LegacyMaterialData {
   uint32_t tFactor = 0xffffffff;  // Value for D3DRS_TEXTUREFACTOR, default value of is opaque white
   D3DMATERIAL9 d3dMaterial = {};
   bool isTextureFactorBlend = false;
+  uint32_t remixTextureCategoryFlagsFromD3D = 0;
+  uint32_t remixHashFromD3D = 0;
 
   void setHashOverride(XXH64_hash_t hash) {
     m_cachedHash = hash;

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -989,6 +989,9 @@ namespace dxvk {
     RTX_OPTION("rtx", float, effectLightRadius, 5.f, "");
     RTX_OPTION("rtx", bool, effectLightPlasmaBall, false, "");
 
+    RTX_OPTION("rtx", bool, useUnusedRenderstates, false, "Enable usage of unused D3D renderstates to aid with special game scenarios whilst having game code access.\n"
+               "(RS 42) Setting the remix texture category for the next surface. (RS 150) Setting a user defined material hash for the next surface.");
+
     RTX_OPTION("rtx", bool, useObsoleteHashOnTextureUpload, false,
                "Whether or not to use slower XXH64 hash on texture upload.\n"
                "New projects should not enable this option as this solely exists for compatibility with older hashing schemes.");


### PR DESCRIPTION
This PR implements logic allowing the usage of two unused d3d9 render states to aid with special game scenarios whilst having game code access.
<br>

### The specific purpose of this PR
I'm currently working on a portal 2 - remix compatibility mod (via reverse engineering - asi loading) and faced an issue with how the game is rendering the speed/jump gel's. 

The game is building a dynamic texture that keeps track of which surfaces on the map are covered by gel. It is very similar to a lightmap texture and because it is a dynamic texture, the hash is dynamically changing as well.  This prevents me from remixing it in the toolkit.

The gel texture also requires two remix texture categories to be set (`IgnoreOpacityMicromap + Decal`) for it to look correct. 
This is not possible with the hash constantly changing.

![Screenshot 2024-10-12 142540](https://github.com/user-attachments/assets/3daa0770-0e1b-49ec-bded-c0a940541c2e)
Footage of gel being applied to surfaces (Showcase Discord):
https://discord.com/channels/1028444667789967381/1028600697463263314/1294618442346926152
<br>

### In short:
When the hidden remix option 'useUnusedRenderstates' is enabled via the rtx.conf:
1) Unused render state 42 can be used to assign a remix texture category for the next surface like so:
`device->SetRenderState((D3DRENDERSTATETYPE)42, IgnoreOpacityMicromap | DecalStatic);`
> This does not add the hash to the specified remix option texture list as that is unnecessary
and would bloat it over time.

> The code is checking bit flags. The enum I'm using matches the `InstanceCategories` enum class:
```cpp
enum RemixInstanceCategories : uint32_t
{
	WorldUI			= 1 << 0,
	WorldMatte		= 1 << 1,
	Sky			= 1 << 2,
	Ignore			= 1 << 3,
	IgnoreLights		= 1 << 4,
	IgnoreAntiCulling	= 1 << 5,
	IgnoreMotionBlur	= 1 << 6,
	IgnoreOpacityMicromap	= 1 << 7,
	IgnoreAlphaChannel 	= 1 << 8,
	Hidden			= 1 << 9,
	Particle		= 1 << 10,
	Beam			= 1 << 11,
	DecalStatic		= 1 << 12,
	DecalDynamic		= 1 << 13,
	DecalSingleOffset	= 1 << 14,
	DecalNoOffset		= 1 << 15,
	AlphaBlendToCutout	= 1 << 16,
	Terrain			= 1 << 17,
	AnimatedWater		= 1 << 18,
	ThirdPersonPlayerModel	= 1 << 19,
	ThirdPersonPlayerBody	= 1 << 20,
	IgnoreBakedLighting	= 1 << 21,
};
```
<br>

2) Unused render state 150 can be used to set a custom material hash for the next surface like so:
`device->SetRenderState((D3DRENDERSTATETYPE)150, 0x1337);`

![Screenshot 2024-10-12 133747](https://github.com/user-attachments/assets/a474456b-5158-42fe-a5d0-9890e7cb4cb3)


### Thoughts
- Rendering the gel using the remixAPI is currently not possible as the api only works with paths to actual dds textures on disk and does not expose a way to use "texture data" by providing a `IDirect3DBaseTexture9` pointer. I'll create a separate feature request for that. (Even if that would work, I'm not entirely sure if I could render the gel using the api)

- This PR is only useful for people working on __compatibility mods__ for shader heavy game with game code access. It should not affect or change anything for other remix supported games as the render states utilized are unused since ... ?