### PR TITLE
RayPortalMaterialData: Use albedo texture as portal mask

### DIFF
--- a/src/dxvk/rtx_render/rtx_remix_api.cpp
+++ b/src/dxvk/rtx_render/rtx_remix_api.cpp
@@ -301,7 +301,7 @@ namespace {
         const auto& src = materialWithoutPreload.getRayPortalMaterialData();
         return MaterialData { RayPortalMaterialData {
           preloadTexture(preload.emissiveTexture),
-          {}, // unused
+          preloadTexture(preload.albedoTexture), // portal mask
           src.getRayPortalIndex(),
           src.getSpriteSheetRows(),
           src.getSpriteSheetCols(),


### PR DESCRIPTION
This small change allows the usage of the albedo texture to define the rayportal shape when creating a rayportal material via the remixApi.

Background:
The shape of the portal gets estimated if `MaskTexture2` is unset. 
This results in a perfect circle but that might not always be the desired shape. 
In case of portal 2, I actually need square portals for room/area connecting portals that are placed within sliding doors or similar.
Using a blank white texture results in just that. Not setting an albedo means that the portal shape will be estimated just like before.

Note:
I think it might be beneficial to expose that setting to usd/toolkit. From what I can tell it's already hooked up in code .. just unused:

```cpp
#define LIST_PORTAL_MATERIAL_TEXTURES(X) \
  /*Parameter Name, USD Token String,       Type,       UNUSED...   Default Value */ \
  X(MaskTexture,    emissive_mask_texture,  TextureRef, void, void, {}) \
  X(MaskTexture2,   unused_in_usd_so_dont,  TextureRef, void, void, {})
```

https://github.com/NVIDIAGameWorks/dxvk-remix/blob/912a1646ea7f11b23f9f7c590119fa8d8f1b2c33/src/dxvk/rtx_render/rtx_scene_manager.cpp#L1096