### PR TITLE
Add tests/rtx/dxvk_rt_testing/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 /external
 **/_batch_output/**
 /public/bin/
+tests/rtx/dxvk_rt_testing


### PR DESCRIPTION
Add's `tests/rtx/dxvk_rt_testing` to `.gitignore` to ignore the hundreds of test files after compiling the solution.

Before:
![Screenshot 2024-11-01 185743](https://github.com/user-attachments/assets/c501e31e-2c6b-4220-88e4-bde21ba0e041)

Note:
I sometimes need to delete this directory to be able to compile the solution.
![image](https://github.com/user-attachments/assets/a6585219-20b5-498c-8d5c-60a23b312fc4)

