### PR TITLE
Game Capturer: Prevent meshes drawn via the remixapi from being captured

### DIFF
--- a/src/dxvk/rtx_render/rtx_remix_api.cpp
+++ b/src/dxvk/rtx_render/rtx_remix_api.cpp
@@ -871,11 +871,13 @@ namespace {
     if (!remixDevice) {
       return REMIXAPI_ERROR_CODE_REMIX_DEVICE_WAS_NOT_REGISTERED;
     }
-    std::lock_guard lock { s_mutex };
-    remixDevice->EmitCs([cRtDrawState = convert::toRtDrawState(*info)](dxvk::DxvkContext* dxvkCtx) mutable {
-      auto* ctx = static_cast<dxvk::RtxContext*>(dxvkCtx);
-      ctx->commitExternalGeometryToRT(std::move(cRtDrawState));
-    });
+    if (dxvk::RtxOptions::Get()->getEnableAnyReplacements()) {
+      std::lock_guard lock { s_mutex };
+      remixDevice->EmitCs([cRtDrawState = convert::toRtDrawState(*info)](dxvk::DxvkContext* dxvkCtx) mutable {
+        auto* ctx = static_cast<dxvk::RtxContext*>(dxvkCtx);
+        ctx->commitExternalGeometryToRT(std::move(cRtDrawState));
+      });
+    }
     return REMIXAPI_ERROR_CODE_SUCCESS;
   }
 


### PR DESCRIPTION
This is band-aid or the fix for [#671](https://github.com/NVIDIAGameWorks/rtx-remix/issues/671).

Disabling replacements (required for taking a capture) will now also prevent api meshes from being added.
