### PR TITLE
Rayportals: Disable fade-in effect for portals with to emissive texture

### DIFF
--- a/src/dxvk/shaders/rtx/algorithm/resolve.slangh
+++ b/src/dxvk/shaders/rtx/algorithm/resolve.slangh
@@ -581,7 +581,7 @@ void resolveVertex<T: IBasePayloadState>(
 
     // Render Portal outline
     {
-      const bool portalFadeInEffect = cb.enablePortalFadeInEffect;
+      const bool portalFadeInEffect = cb.enablePortalFadeInEffect && rayPortalSurfaceMaterial.maskTextureIndex != BINDING_INDEX_INVALID;
       const float16_t tFactor = portalFadeInEffect ? float16_t((surface.tFactor >> 24) & 0xff) / 255.0 : float16_t(0.0);
       const float16_t ringTransparency =
         saturate(float16_t(1) - rayPortalSurfaceMaterialInteraction.mask.a) *


### PR DESCRIPTION
This small change disables the fade-in effect on rayportals that have no emissive texture set.

### The issue:
Drawing a rayportal whilst having the runtime option "Portals: Fade in Effect" enabled results in a gray, non see-through portal: 
`const float16_t tFactor = portalFadeInEffect ? float16_t((surface.tFactor >> 24) & 0xff) / 255.0 : float16_t(0.0);` 
> -> There is no way to set the tFactor for the surface via the api.

![Screenshot 2024-11-02 112822](https://github.com/user-attachments/assets/7f1b9ccc-2142-492a-9a12-4078bd8aadf5)

Now, I could disable the global fade-in option but that will also affect the actual game portals:
![Screenshot 2024-11-02 112829](https://github.com/user-attachments/assets/43311f90-7243-4d7f-9cf0-05e47545af31)

And with the fix:
![Screenshot 2024-11-02 112415](https://github.com/user-attachments/assets/ea203793-c56a-4313-922b-7adedc179cb7)
