### PR TITLE
RemixApi: add AddTextureHash and RemoveTextureHash methods

### DIFF
--- a/public/include/remix/remix.h
+++ b/public/include/remix/remix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -173,6 +173,8 @@ namespace remix {
     Result< void >                    DestroyLight(remixapi_LightHandle handle);
     Result< void >                    DrawLightInstance(remixapi_LightHandle handle);
     Result< void >                    SetConfigVariable(const char* key, const char* value);
+    Result< void >                    AddTextureHash(const char* textureCategory, const char* textureHash);
+    Result< void >                    RemoveTextureHash(const char* textureCategory, const char* textureHash);
 
     // DXVK interoperability
     Result< IDirect3D9Ex* >                  dxvk_CreateD3D9(bool editorModeEnabled = false);
@@ -208,7 +210,7 @@ namespace remix {
         return status;
       }
 
-      static_assert(sizeof(remixapi_Interface) == 168,
+      static_assert(sizeof(remixapi_Interface) == 184,
                     "Change version, update C++ wrapper when adding new functions");
 
       remix::Interface interfaceInCpp = {};
@@ -249,6 +251,20 @@ namespace remix {
       return REMIXAPI_ERROR_CODE_NOT_INITIALIZED;
     }
     return m_CInterface.SetConfigVariable(key, value);
+  }
+
+  inline Result< void > Interface::AddTextureHash(const char* textureCategory, const char* textureHash) {
+    if (!m_CInterface.AddTextureHash) {
+      return REMIXAPI_ERROR_CODE_NOT_INITIALIZED;
+    }
+    return m_CInterface.AddTextureHash(textureCategory, textureHash);
+  }
+
+  inline Result< void > Interface::RemoveTextureHash(const char* textureCategory, const char* textureHash) {
+    if (!m_CInterface.RemoveTextureHash) {
+      return REMIXAPI_ERROR_CODE_NOT_INITIALIZED;
+    }
+    return m_CInterface.RemoveTextureHash(textureCategory, textureHash);
   }
 
   inline Result< void > Interface::Present(const remixapi_PresentInfo* info) {

--- a/public/include/remix/remix_c.h
+++ b/public/include/remix/remix_c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -53,7 +53,7 @@
 #define REMIXAPI_VERSION_GET_PATCH(version) (((uint64_t)(version)      ) & (uint64_t)0xFFFF)
 
 #define REMIXAPI_VERSION_MAJOR 0
-#define REMIXAPI_VERSION_MINOR 5
+#define REMIXAPI_VERSION_MINOR 6
 #define REMIXAPI_VERSION_PATCH 1
 
 
@@ -400,20 +400,20 @@ extern "C" {
     REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_ANTI_CULLING       = 1 << 5,
     REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_MOTION_BLUR        = 1 << 6,
     REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_OPACITY_MICROMAP   = 1 << 7,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_HIDDEN                    = 1 << 8,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_PARTICLE                  = 1 << 9,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_BEAM                      = 1 << 10,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_STATIC              = 1 << 11,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_DYNAMIC             = 1 << 12,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_SINGLE_OFFSET       = 1 << 13,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_NO_OFFSET           = 1 << 14,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_ALPHA_BLEND_TO_CUTOUT     = 1 << 15,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_TERRAIN                   = 1 << 16,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_ANIMATED_WATER            = 1 << 17,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_THIRD_PERSON_PLAYER_MODEL = 1 << 18,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_THIRD_PERSON_PLAYER_BODY  = 1 << 19,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_BAKED_LIGHTING     = 1 << 20,
-    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_ALPHA_CHANNEL      = 1 << 21,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_ALPHA_CHANNEL      = 1 << 8,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_HIDDEN                    = 1 << 9,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_PARTICLE                  = 1 << 10,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_BEAM                      = 1 << 11,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_STATIC              = 1 << 12,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_DYNAMIC             = 1 << 13,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_SINGLE_OFFSET       = 1 << 14,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_NO_OFFSET           = 1 << 15,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_ALPHA_BLEND_TO_CUTOUT     = 1 << 16,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_TERRAIN                   = 1 << 17,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_ANIMATED_WATER            = 1 << 18,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_THIRD_PERSON_PLAYER_MODEL = 1 << 19,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_THIRD_PERSON_PLAYER_BODY  = 1 << 20,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_BAKED_LIGHTING     = 1 << 21,
     REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_TRANSPARENCY_LAYER = 1 << 22,
   } remixapi_InstanceCategoryBit;
 
@@ -562,6 +562,14 @@ extern "C" {
     const char*               key,
     const char*               value);
 
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_AddTextureHash)(
+		const char* textureCategory,
+		const char* textureHash);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_RemoveTextureHash)(
+		const char* textureCategory,
+    const char* textureHash);
+
   typedef struct remixapi_PresentInfo {
     remixapi_StructType       sType;
     void*                     pNext;
@@ -642,6 +650,8 @@ extern "C" {
     PFN_remixapi_DestroyLight       DestroyLight;
     PFN_remixapi_DrawLightInstance  DrawLightInstance;
     PFN_remixapi_SetConfigVariable  SetConfigVariable;
+    PFN_remixapi_AddTextureHash     AddTextureHash;
+    PFN_remixapi_RemoveTextureHash  RemoveTextureHash;
 
     // DXVK interoperability
     PFN_remixapi_dxvk_CreateD3D9            dxvk_CreateD3D9;


### PR DESCRIPTION
This is one part of the PR that covers both the bridge and the runtime. The bridge PR can be found here:
https://github.com/NVIDIAGameWorks/bridge-remix/pull/17

This PR implements two new API methods: `AddTextureHash` and `RemoveTextureHash`.
These can be used to add or remove individual texture hashes from texture category options (hash sets). 
The `SetConfigVariable` is not practical in that regard as it only allows to set the entire option to the specified value and would require the user to craft the entire hash set string.

### Example use cases:
- Some effect or similar that is using texture `XY` is causing issues on a certain map and has to be hidden. But texture `XY` is also used in other parts of the game where it does not cause issues.
- Multiplayer/Coop games where the player character is visible in first person view (and tagged as player body) to allow for shadows or virtual instances (Portal) but the player model changes based on the class/team etc. Prime example would be Portal 2 Coop where two different player models are in use. The two methods allow me to dynamically set/remove the player body texture hashes depending on which character you play.

#### Notheworthy changes:
- increased REMIXAPI_VERSION_MINOR from 5 to 6

#### Included fixes:
- fixes mismatching remixapi_InstanceCategoryBit enum (runtime issue #727) (https://github.com/NVIDIAGameWorks/rtx-remix/issues/727) 
- fixes bridge issue #736 (https://github.com/NVIDIAGameWorks/rtx-remix/issues/736) that was caused by outdated api headers in `ext/remix/`. 