### PR TITLE
ignore all baked vertex color lighting feature

### DIFF
--- a/src/d3d9/d3d9_rtx.cpp
+++ b/src/d3d9/d3d9_rtx.cpp
@@ -253,6 +253,7 @@ namespace dxvk {
         break;
       case D3DDECLUSAGE_COLOR:
         if (element.UsageIndex == 0 &&
+            !RtxOptions::ignoreAllVertexColorBakedLighting() &&
             !lookupHash(RtxOptions::ignoreBakedLightingTextures(), m_activeDrawCallState.materialData.colorTextures[0].getImageHash())) {
           targetBuffer = &geoData.color0Buffer;
         }

--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -2616,6 +2616,7 @@ namespace dxvk {
 
       ImGui::DragFloat("Vertex Color Strength", &RtxOptions::vertexColorStrengthObject(), 0.001f, 0.0f, 1.0f);
       ImGui::Checkbox("Vertex Color Is Baked Lighting", &RtxOptions::vertexColorIsBakedLightingObject());
+      ImGui::Checkbox("Ignore All Baked Lighting", &RtxOptions::ignoreAllVertexColorBakedLightingObject());
       ImGui::Separator();
 
       if (ImGui::CollapsingHeader("Heuristics", collapsingHeaderClosedFlags)) {

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -298,6 +298,7 @@ namespace dxvk {
                "A scalar to apply to how strong vertex color influence should be on materials.\n"
                "A value of 1 indicates that it should be fully considered (though do note the texture operation and relevant parameters still control how much it should be blended with the actual albedo color), a value of 0 indicates that it should be fully ignored.");
     RTX_OPTION("rtx", bool, vertexColorIsBakedLighting, true, "If true, brightness contribution will be removed from the vertex color by dividing each component by the largest component.");
+    RTX_OPTION("rtx", bool, ignoreAllVertexColorBakedLighting, false, "If true, all baked lighting bound to all vertex colors will be ignored.");
     RTX_OPTION("rtx", bool, allowFSE, false,
                "A flag indicating if the application should be able to utilize exclusive full screen mode when set to true, otherwise force it to be disabled when set to false.\n"
                "Exclusive full screen may see performance benefits over other fullscreen modes at the cost of stability in some cases.\n"


### PR DESCRIPTION
This change/feature allows all baked lighting to be ignored during the `processVertices` step, with a toggle-able option in the ImGui vertex options to control the feature, and optionally serialize it into the `rtx.conf`.

This feature is immensely useful for games that use baked lighting on textures, but inconsistently. The alternative would be to manually mark all these textures to ignore their baked lighting, but in games I am currently working with, this would require manual selection of thousands of textures, which is not going to happen. I believe this feature should help other projects and games that face similar challenges. 