### PR TITLE
Add XeSS 2 Upscaler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,3 +39,6 @@
 [submodule "submodules/Detours"]
 	path = submodules/Detours
 	url = https://github.com/microsoft/Detours.git
+[submodule "external/xess"]
+	path = external/xess
+	url = https://github.com/intel/xess.git

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -548,6 +548,7 @@ namespace dxvk {
     m_rayReconstruction(device),
     m_nis(device),
     m_taa(device),
+    m_xess(device),
     m_composite(device),
     m_debug_view(device),
     m_autoExposure(device),

--- a/src/dxvk/dxvk_objects.h
+++ b/src/dxvk/dxvk_objects.h
@@ -45,6 +45,7 @@
 #include "rtx_render/rtx_dlss.h"
 #include "rtx_render/rtx_nis.h"
 #include "rtx_render/rtx_taa.h"
+#include "rtx_render/rtx_xess.h"
 #include "rtx_render/rtx_auto_exposure.h"
 #include "rtx_render/rtx_tone_mapping.h"
 #include "rtx_render/rtx_local_tone_mapping.h"
@@ -221,6 +222,10 @@ namespace dxvk {
       return m_taa.get();
     }
 
+    DxvkXeSS& metaXeSS() {
+      return m_xess.get();
+    }
+
     CompositePass& metaComposite() {
       return m_composite.get();
     }
@@ -368,6 +373,7 @@ namespace dxvk {
     Active<DxvkRayReconstruction>           m_rayReconstruction;
     Active<DxvkNIS>                         m_nis;
     Active<DxvkTemporalAA>                  m_taa;
+    Active<DxvkXeSS>                        m_xess;
     Active<CompositePass>                   m_composite;
     Active<DebugView>                       m_debug_view;
     Active<DxvkAutoExposure>                m_autoExposure;

--- a/src/dxvk/imgui/dxvk_imgui_about.cpp
+++ b/src/dxvk/imgui/dxvk_imgui_about.cpp
@@ -92,6 +92,7 @@ namespace dxvk {
     : m_sections({
       { "Github Contributors", // Sorted alphabetically by last name
         { "Lorenzo 'King Vulpes' Acevedo IV",
+          "Samuel 'CR' Bowman'",
           "Alexis 'Sortifal' Bruneteau",
           "Ethan 'Xenthio' Cardwell",
           "Alexander 'xoxor4d' Engel",

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -211,8 +211,10 @@ dxvk_src = files([
   'rtx_render/rtx_denoise_type.h',
   'rtx_render/rtx_dlfg.cpp',
   'rtx_render/rtx_dlfg.h',
-  'rtx_render/rtx_dlss.cpp', 
+  'rtx_render/rtx_dlss.cpp',
   'rtx_render/rtx_dlss.h',
+  'rtx_render/rtx_xess.cpp',
+  'rtx_render/rtx_xess.h',
   'rtx_render/rtx_draw_call_cache.cpp',
   'rtx_render/rtx_draw_call_cache.h',
   'rtx_render/rtx_env.cpp',
@@ -414,6 +416,11 @@ dlss_dep = declare_dependency(
   include_directories : [ dlss_include_dir, dlfg_include_dir ]
 )
 
+# XeSS dependency - using direct library path
+xess_lib_path = join_paths(global_src_root_norm, 'external/xess/lib')
+xess_lib = cc.find_library('libxess', dirs : xess_lib_path, required : false)
+xess_dep = declare_dependency(dependencies : [ xess_lib ])
+
 nrc_dll_path = join_paths(meson.global_source_root(), 'submodules/nrc/bin/')
 nrc_lib_path = join_paths(meson.global_source_root(), 'submodules/nrc/lib/')
 nrc_lib = dxvk_compiler.find_library('NRC_Vulkan', dirs : nrc_lib_path, required : true)
@@ -441,7 +448,7 @@ dxvk_embedded_data_files = files([
 
 dxvk_generated_embedded_files = embedding_compiler.process(dxvk_embedded_data_files)
 
-dxvk_deps = [ thread_dep, vkcommon_dep, dxvk_extradep, usd_dep, lssUsd_dep, nrc_dep, nrd_dep, dlss_dep, submodules_dep, tracy_dep, tracy_dep_dynamic, aftermath_dep, nvapi_dep, reflex_dep, usd_plugin_deps ]
+dxvk_deps = [ thread_dep, vkcommon_dep, dxvk_extradep, usd_dep, lssUsd_dep, nrc_dep, nrd_dep, dlss_dep, submodules_dep, xess_dep, tracy_dep, tracy_dep_dynamic, aftermath_dep, nvapi_dep, reflex_dep ]
 
 if enable_rtxio
   dxvk_deps += rtxio_dep

--- a/src/dxvk/rtx_render/rtx_camera.cpp
+++ b/src/dxvk/rtx_render/rtx_camera.cpp
@@ -736,9 +736,67 @@ namespace dxvk
     jitter[1] = m_jitter[1];
   }
 
+  // Static variable to track the actual jitter sequence length being used
+  static uint32_t s_currentJitterSequenceLength = 64;
+  
+  // Static variable to track the current upscaling ratio for dynamic jitter calculation
+  static float s_currentUpscalingRatio = 1.0f;
+
   Vector2 RtCamera::calcPixelJitter(uint32_t jitterFrameIdx) {
-    // Only apply jittering when DLSS/TAA is enabled, or if forced by settings
+    // Only apply jittering when DLSS/XeSS/TAA is enabled, or if forced by settings
     if (!RtxOptions::isDLSSOrRayReconstructionEnabled() &&
+        !RtxOptions::isXeSSEnabled() &&
+        !RtxOptions::isTAAEnabled() &&
+        !RtxOptions::forceCameraJitter()) {
+      s_currentJitterSequenceLength = 0; // No jitter being used
+      return Vector2{ 0, 0 };
+    }
+
+#define USE_DLSS_DEMO_JITTER_PATTERN 1
+#if USE_DLSS_DEMO_JITTER_PATTERN
+    uint32_t jitterSequenceLength = RtxOptions::cameraJitterSequenceLength();
+
+    if (RtxOptions::isXeSSEnabled() && RtxOptions::xessUseRecommendedJitterSequenceLength()) {
+      float scaleFactor = s_currentUpscalingRatio;
+      uint32_t xessLength = static_cast<uint32_t>(std::ceil(scaleFactor * scaleFactor * 8.0f));
+      
+      // Apply minimum jitter sequence length
+      uint32_t minLength = RtxOptions::xessMinJitterSequenceLength();
+      xessLength = std::max(xessLength, minLength);
+      
+      // Clamp to reasonable range
+      xessLength = std::clamp(xessLength, minLength, 1024u);
+      jitterSequenceLength = xessLength;
+    }
+    
+    // Track the actual jitter sequence length being used
+    s_currentJitterSequenceLength = jitterSequenceLength;
+    
+    return calculateHaltonJitter(jitterFrameIdx, jitterSequenceLength);
+#else
+    s_currentJitterSequenceLength = 1; // Halton sequence is effectively length 1
+    return m_halton.next();
+#endif
+  }
+
+  uint32_t RtCamera::getCurrentJitterSequenceLength() {
+    return s_currentJitterSequenceLength;
+  }
+  
+  void RtCamera::setCurrentUpscalingRatio(float upscalingRatio) {
+    if (s_currentUpscalingRatio != upscalingRatio) {
+      s_currentUpscalingRatio = upscalingRatio;
+    }
+  }
+  
+  float RtCamera::getCurrentUpscalingRatio() {
+    return s_currentUpscalingRatio;
+  }
+  
+  Vector2 RtCamera::calcPixelJitterWithXeSS(uint32_t jitterFrameIdx, uint32_t xessLength) {
+    // Only apply jittering when DLSS/XeSS/TAA is enabled, or if forced by settings
+    if (!RtxOptions::isDLSSOrRayReconstructionEnabled() &&
+        !RtxOptions::isXeSSEnabled() &&
         !RtxOptions::isTAAEnabled() &&
         !RtxOptions::forceCameraJitter()) {
       return Vector2{ 0, 0 };
@@ -746,7 +804,13 @@ namespace dxvk
 
 #define USE_DLSS_DEMO_JITTER_PATTERN 1
 #if USE_DLSS_DEMO_JITTER_PATTERN
+  if (RtxOptions::isXeSSEnabled() && RtxOptions::xessUseRecommendedJitterSequenceLength() && xessLength > 0) {
+    // XeSS-specific: Use the recommended jitter sequence length
+    return calculateHaltonJitter(jitterFrameIdx, xessLength);
+  } else {
+    // Original behavior for DLSS, TAA, and other upscalers
     return calculateHaltonJitter(jitterFrameIdx, RtxOptions::cameraJitterSequenceLength());
+  }
 #else
     return m_halton.next();
 #endif
@@ -823,6 +887,7 @@ namespace dxvk
     camera.projectionToView = projectionToView;
     camera.viewToProjectionJittered = viewToProjectionJittered;
     camera.projectionToViewJittered = projectionToViewJittered;
+    camera.worldToProjection = viewToProjection * worldToView;
     camera.worldToProjectionJittered = viewToProjectionJittered * worldToView;
     camera.projectionToWorldJittered = viewToWorld * projectionToViewJittered;
     camera.translatedWorldToView = translatedWorldToView;
@@ -875,6 +940,7 @@ namespace dxvk
 
     camera.viewToProjection = viewToProjection;
     camera.translatedWorldToView = translatedWorldToView;
+    camera.translatedWorldToProjection = viewToProjection * translatedWorldToView;
     camera.translatedWorldToProjectionJittered = viewToProjectionJittered * translatedWorldToView;
     camera.projectionToTranslatedWorld = viewToTranslatedWorld * projectionToView;
     camera.prevTranslatedWorldToView = prevTranslatedWorldToView;

--- a/src/dxvk/rtx_render/rtx_camera.h
+++ b/src/dxvk/rtx_render/rtx_camera.h
@@ -315,6 +315,10 @@ namespace dxvk
     bool isLHS() const { return m_context.isLHS; }
 
     static Vector2 calcPixelJitter(uint32_t jitterFrameIdx);
+    static Vector2 calcPixelJitterWithXeSS(uint32_t jitterFrameIdx, uint32_t xessLength);
+    static uint32_t getCurrentJitterSequenceLength();
+    static void setCurrentUpscalingRatio(float upscalingRatio);
+    static float getCurrentUpscalingRatio();
     static Vector2 calcClipSpaceJitter(Vector2 pixelJitter, uint32_t renderResolutionX, uint32_t renderResolutionY, float ratioX, float ratioY);
     static void applyJitterTo(Matrix4& inoutProjection, uint32_t jitterFrameIdx, uint32_t renderResolutionX, uint32_t renderResolutionY);
     static void applyAndGetJitter(Matrix4d& inoutProjection, float (&outPixelJitter)[2], uint32_t jitterFrameIdx, uint32_t renderResolutionX, uint32_t renderResolutionY);

--- a/src/dxvk/rtx_render/rtx_context.cpp
+++ b/src/dxvk/rtx_render/rtx_context.cpp
@@ -234,6 +234,20 @@ namespace dxvk {
       downscaleExtent.width = renderSize[0];
       downscaleExtent.height = renderSize[1];
       downscaleExtent.depth = 1;
+    } else if (shouldUseXeSS()) {
+      DxvkXeSS& xess = m_common->metaXeSS();
+      uint32_t displaySize[2] = { upscaleExtent.width, upscaleExtent.height };
+      uint32_t renderSize[2];
+      xess.setSetting(displaySize, RtxOptions::xessProfile(), renderSize);
+      downscaleExtent.width = renderSize[0];
+      downscaleExtent.height = renderSize[1];
+      downscaleExtent.depth = 1;
+      
+      // XeSS: Apply recommended jitter sequence length if enabled
+      if (RtxOptions::xessUseRecommendedJitterSequenceLength() && xess.isActive()) {
+        uint32_t recommendedJitterLength = xess.getRecommendedJitterSequenceLength();
+        uint32_t currentJitterLength = RtxOptions::cameraJitterSequenceLength();
+      }
     } else if (shouldUseNIS() || shouldUseTAA()) {
       auto resolutionScale = RtxOptions::resolutionScale();
       downscaleExtent.width = uint32_t(std::roundf(upscaleExtent.width * resolutionScale));
@@ -291,6 +305,8 @@ namespace dxvk {
       return InternalUpscaler::DLSS;
     } else if (shouldUseRayReconstruction() && m_common->metaRayReconstruction().isActive()) {
       return InternalUpscaler::DLSS_RR;
+    } else if (shouldUseXeSS() && m_common->metaXeSS().isActive()) {
+      return InternalUpscaler::XeSS;
     } else if (shouldUseNIS()) {
       return InternalUpscaler::NIS;
     } else if (shouldUseTAA()) {
@@ -614,6 +630,9 @@ namespace dxvk {
         } else if (m_currentUpscaler == InternalUpscaler::DLSS_RR) {
           m_common->metaAutoExposure().createResources(this);
           dispatchRayReconstruction(rtOutput);
+        } else if (m_currentUpscaler == InternalUpscaler::XeSS) {
+          m_common->metaAutoExposure().createResources(this);
+          dispatchXeSS(rtOutput);
         } else if (m_currentUpscaler == InternalUpscaler::NIS) {
           dispatchNIS(rtOutput);
         } else if (m_currentUpscaler == InternalUpscaler::TAAU){
@@ -1561,6 +1580,13 @@ namespace dxvk {
     m_common->metaNIS().dispatch(this, rtOutput);
   }
 
+  void RtxContext::dispatchXeSS(const Resources::RaytracingOutput& rtOutput) {
+    ScopedGpuProfileZone(this, "XeSS");
+    setFramePassStage(RtxFramePassStage::XeSS);
+    DxvkXeSS& xess = m_common->metaXeSS();
+    xess.dispatch(this, m_execBarriers, rtOutput, m_resetHistory);
+  }
+
   void RtxContext::dispatchTemporalAA(const Resources::RaytracingOutput& rtOutput) {
     ScopedGpuProfileZone(this, "TAA");
     setFramePassStage(RtxFramePassStage::TAA);
@@ -2091,6 +2117,10 @@ namespace dxvk {
 
   bool RtxContext::shouldUseTAA() const {
     return RtxOptions::isTAAEnabled();
+  }
+
+  bool RtxContext::shouldUseXeSS() const {
+    return RtxOptions::upscalerType() == UpscalerType::XeSS;
   }
 
   D3D9RtxVertexCaptureData& RtxContext::allocAndMapVertexCaptureConstantBuffer() {

--- a/src/dxvk/rtx_render/rtx_context.h
+++ b/src/dxvk/rtx_render/rtx_context.h
@@ -166,6 +166,7 @@ namespace dxvk {
       DLSS,
       NIS,
       TAAU,
+      XeSS,
       DLSS_RR,
     };
 
@@ -192,6 +193,7 @@ namespace dxvk {
     void dispatchComposite(const Resources::RaytracingOutput& rtOutput);
     void dispatchReplaceCompositeWithDebugView(const Resources::RaytracingOutput& rtOutput);
     void dispatchNIS(const Resources::RaytracingOutput& rtOutput);
+    void dispatchXeSS(const Resources::RaytracingOutput& rtOutput);
     void dispatchTemporalAA(const Resources::RaytracingOutput& rtOutput);
     void dispatchToneMapping(const Resources::RaytracingOutput& rtOutput, bool performSRGBConversion);
     void dispatchBloom(const Resources::RaytracingOutput& rtOutput);
@@ -232,7 +234,8 @@ namespace dxvk {
     bool shouldUseRayReconstruction() const;
     bool shouldUseNIS() const;
     bool shouldUseTAA() const;
-    bool shouldUseUpscaler() const { return shouldUseDLSS() || shouldUseNIS() || shouldUseTAA(); }
+    bool shouldUseXeSS() const;
+    bool shouldUseUpscaler() const { return shouldUseDLSS() || shouldUseNIS() || shouldUseTAA() || shouldUseXeSS(); }
 
     inline static bool s_triggerScreenshot = false;
     inline static bool s_triggerUsdCapture = false;

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -64,7 +64,8 @@ namespace dxvk {
     None = 0,
     DLSS,
     NIS,
-    TAAU
+    TAAU,
+    XeSS
   };
 
   enum class GraphicsPreset : int {
@@ -87,6 +88,18 @@ namespace dxvk {
     Off = 0,
     On,
     Custom
+  };
+
+  enum class XeSSProfile : int {
+    UltraPerf = 0,
+    Performance,
+    Balanced,
+    Quality,
+    UltraQuality,
+    UltraQualityPlus,
+    NativeAA,
+    Custom,
+    Invalid
   };
 
   enum class NisPreset : int {
@@ -290,6 +303,15 @@ namespace dxvk {
     RTX_OPTION_ENV("rtx", DlssPreset, dlssPreset, DlssPreset::On, "RTX_DLSS_PRESET", "Combined DLSS Preset for quickly controlling Upscaling, Frame Interpolation and Latency Reduction.");
     RTX_OPTION("rtx", NisPreset, nisPreset, NisPreset::Balanced, "Adjusts NIS scaling factor, trades quality for performance.");
     RTX_OPTION("rtx", TaauPreset, taauPreset, TaauPreset::Balanced,  "Adjusts TAA-U scaling factor, trades quality for performance.");
+    RTX_OPTION("rtx", XeSSProfile, xessProfile, XeSSProfile::Balanced, "Adjusts XeSS scaling factor, trades quality for performance.");
+
+    RTX_OPTION("rtx", float, xessJitterScale, 1.0f, "Multiplier for XeSS jitter intensity. Values > 1.0 increase jitter, < 1.0 reduce it. Can help reduce aliasing or temporal artifacts.");
+    RTX_OPTION("rtx", bool, xessUseOptimizedJitter, true, "Use XeSS-optimized jitter patterns and scaling. When disabled, uses the same jitter as other upscalers.");
+    RTX_OPTION("rtx", bool, xessUseRecommendedJitterSequenceLength, true, "Use XeSS 2.1 recommended jitter sequence length calculation based on scaling factor. When disabled, uses the global cameraJitterSequenceLength setting.");
+    RTX_OPTION("rtx", float, xessResponsivePixelMaskClampValue, 0.8f, "Maximum value to clamp responsive pixel mask to. XeSS 2.1 default is 0.8 to prevent aliasing artifacts.");
+    RTX_OPTION("rtx", float, xessScalingJitterDamping, 0.6f, "Additional jitter damping factor to reduce swimming artifacts. Lower values = less jitter.");
+    RTX_OPTION("rtx", bool, xessLogJitterSequenceLength, false, "Log the current jitter sequence length being used for XeSS. Useful for debugging swimming artifacts.");
+    RTX_OPTION("rtx", uint32_t, xessMinJitterSequenceLength, 8, "Minimum jitter sequence length for XeSS, even at low scaling factors.");
     RTX_OPTION_ENV("rtx", GraphicsPreset, graphicsPreset, GraphicsPreset::Auto, "DXVK_GRAPHICS_PRESET_TYPE", "Overall rendering preset, higher presets result in higher image quality, lower presets result in better performance.");
     RTX_OPTION_ENV("rtx", RaytraceModePreset, raytraceModePreset, RaytraceModePreset::Auto, "DXVK_RAYTRACE_MODE_PRESET_TYPE", "");
     RTX_OPTION("rtx", float, emissiveIntensity, 1.0f, "A general scale factor on all emissive intensity values globally. Generally per-material emissive intensities should be used, but this option may be useful for debugging without needing to author materials.");
@@ -1233,6 +1255,7 @@ namespace dxvk {
     static void updateUpscalerFromDlssPreset();
     static void updateUpscalerFromNisPreset();
     static void updateUpscalerFromTaauPreset();
+    static void updateUpscalerFromXeSSPreset();
     static void updatePresetFromUpscaler();
     static NV_GPU_ARCHITECTURE_ID getNvidiaArch();
     static NV_GPU_ARCH_IMPLEMENTATION_ID getNvidiaChipId();
@@ -1304,6 +1327,7 @@ namespace dxvk {
     }
     static bool isNISEnabled() { return upscalerType() == UpscalerType::NIS; }
     static bool isTAAEnabled() { return upscalerType() == UpscalerType::TAAU; }
+    static bool isXeSSEnabled() { return upscalerType() == UpscalerType::XeSS; }
     
     static float getUniqueObjectDistanceSqr() { return uniqueObjectDistance() * uniqueObjectDistance(); }
     static uint32_t getNumFramesToPutLightsToSleep() { return numFramesToKeepLights() /2; }

--- a/src/dxvk/rtx_render/rtx_resources.h
+++ b/src/dxvk/rtx_render/rtx_resources.h
@@ -404,6 +404,17 @@ namespace dxvk
     Rc<DxvkSampler> getSampler(const VkFilter filter, const VkSamplerMipmapMode mipFilter, 
                                const VkSamplerAddressMode addrMode, 
                                const float mipBias = 0, const bool useAnisotropy = false);
+    
+    // XeSS: Get sampler with automatic XeSS-specific mip bias calculation
+    Rc<DxvkSampler> getSamplerWithXeSSMipBias(const VkFilter filter, const VkSamplerMipmapMode mipFilter,
+                                               const VkSamplerAddressMode addressModeU,
+                                               const VkSamplerAddressMode addressModeV,
+                                               const VkSamplerAddressMode addressModeW,
+                                               const VkClearColorValue borderColor = VkClearColorValue(),
+                                               const float additionalMipBias = 0, const bool useAnisotropy = false);
+    Rc<DxvkSampler> getSamplerWithXeSSMipBias(const VkFilter filter, const VkSamplerMipmapMode mipFilter, 
+                                               const VkSamplerAddressMode addrMode, 
+                                               const float additionalMipBias = 0, const bool useAnisotropy = false);
 
     Tlas& getTLAS(Tlas::Type type) { return m_tlas[type]; }
 

--- a/src/dxvk/rtx_render/rtx_scene_manager.h
+++ b/src/dxvk/rtx_render/rtx_scene_manager.h
@@ -187,7 +187,8 @@ public:
   
   uint32_t getActivePOMCount() {return m_activePOMCount;}
 
-  float getTotalMipBias();
+    float getTotalMipBias();
+    float getCalculatedUpscalingMipBias();
 
   // ISceneManager but not really
   void clear(Rc<DxvkContext> ctx, bool needWfi);

--- a/src/dxvk/rtx_render/rtx_types.h
+++ b/src/dxvk/rtx_render/rtx_types.h
@@ -908,6 +908,7 @@ enum class RtxFramePassStage {
   DLSS,
   DLSSRR,
   NIS,
+  XeSS,
   TAA,
   DustParticles,
   Bloom,

--- a/src/dxvk/rtx_render/rtx_xess.cpp
+++ b/src/dxvk/rtx_render/rtx_xess.cpp
@@ -1,0 +1,990 @@
+/*
+* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+* DEALINGS IN THE SOFTWARE.
+*/
+#include <locale>
+#include <codecvt>
+#include <cassert>
+
+#include "rtx.h"
+#include "rtx_context.h"
+#include "rtx_options.h"
+#include "dxvk_device.h"
+#include "rtx_xess.h"
+#include "rtx_camera.h"
+#include "dxvk_scoped_annotation.h"
+#include "rtx_render/rtx_shader_manager.h"
+#include "rtx_imgui.h"
+#include "rtx_auto_exposure.h"
+#include "../../util/util_math.h"
+#include "../util/util_string.h"
+#include "../util/log/log.h"
+
+#if defined(_WIN32) && !defined(DXVK_NATIVE)
+#pragma comment(lib, "libxess.lib")
+#endif
+
+#include "../../../external/xess/inc/xess/xess.h"
+#include "../../../external/xess/inc/xess/xess_vk.h"
+#include "../../../external/xess/inc/xess/xess_debug.h"
+
+namespace dxvk {
+  const char* xessProfileToString(XeSSProfile xessProfile) {
+    switch (xessProfile) {
+    case XeSSProfile::UltraPerf: return "Ultra Performance";
+    case XeSSProfile::Performance: return "Performance";
+    case XeSSProfile::Balanced: return "Balanced";
+    case XeSSProfile::Quality: return "Quality";
+    case XeSSProfile::UltraQuality: return "Ultra Quality";
+    case XeSSProfile::UltraQualityPlus: return "Ultra Quality Plus";
+    case XeSSProfile::NativeAA: return "Native Anti-Aliasing";
+    case XeSSProfile::Custom: return "Custom";
+    default:
+      assert(false);
+    case XeSSProfile::Invalid: return "Invalid";
+    }
+  }
+
+  // Helper function to convert XeSS result to string
+  static const char* xessResultToString(xess_result_t result) {
+    switch (result) {
+      case XESS_RESULT_SUCCESS: return "Success";
+      case XESS_RESULT_WARNING_NONEXISTING_FOLDER: return "Warning: Nonexisting folder";
+      case XESS_RESULT_WARNING_OLD_DRIVER: return "Warning: Old driver";
+      case XESS_RESULT_ERROR_UNSUPPORTED_DEVICE: return "Error: Unsupported device";
+      case XESS_RESULT_ERROR_UNSUPPORTED_DRIVER: return "Error: Unsupported driver";
+      case XESS_RESULT_ERROR_UNINITIALIZED: return "Error: Uninitialized";
+      case XESS_RESULT_ERROR_INVALID_ARGUMENT: return "Error: Invalid argument";
+      case XESS_RESULT_ERROR_DEVICE_OUT_OF_MEMORY: return "Error: Device out of memory";
+      case XESS_RESULT_ERROR_DEVICE: return "Error: Device error";
+      case XESS_RESULT_ERROR_NOT_IMPLEMENTED: return "Error: Not implemented";
+      case XESS_RESULT_ERROR_INVALID_CONTEXT: return "Error: Invalid context";
+      case XESS_RESULT_ERROR_OPERATION_IN_PROGRESS: return "Error: Operation in progress";
+      case XESS_RESULT_ERROR_UNSUPPORTED: return "Error: Unsupported";
+      case XESS_RESULT_ERROR_CANT_LOAD_LIBRARY: return "Error: Can't load library";
+      case XESS_RESULT_ERROR_WRONG_CALL_ORDER: return "Error: Wrong call order";
+      case XESS_RESULT_ERROR_UNKNOWN: return "Error: Unknown";
+      default: return "Unknown result code";
+    }
+  }
+
+
+
+  // Constructor with device
+  DxvkXeSS::DxvkXeSS(DxvkDevice* device) 
+    : RtxPass(device),
+      m_device(device),
+      m_initialized(false),
+      m_xessContext(nullptr),
+      m_targetExtent{0, 0, 0},
+      m_inputExtent{0, 0, 0},
+      m_currentProfile(XeSSProfile::Balanced),
+      m_isUsingInternalAutoExposure(false),
+      m_context(nullptr),
+      m_profile(XeSSProfile::Balanced),
+      m_actualProfile(XeSSProfile::Balanced),
+      m_inputSize{0, 0},
+      m_xessOutputSize{0, 0},
+      m_recreate(false),
+      m_lastResolutionScale(-1.0f) {
+    Logger::info("XeSS: Initializing XeSS upscaler...");
+  }
+
+  DxvkXeSS::~DxvkXeSS() {
+    destroyXeSSContext();
+  }
+
+  // RtxPass interface implementations
+  bool DxvkXeSS::isEnabled() const {
+    return RtxOptions::isXeSSEnabled();
+  }
+
+  bool DxvkXeSS::onActivation(Rc<DxvkContext>& ctx) {
+    Logger::info("XeSS: Activating XeSS upscaler...");
+    
+    // Check if XeSS is supported on this system (use stored device pointer)
+    if (!validateXeSSSupport(m_device)) {
+      Logger::warn("XeSS: System does not support XeSS - activation failed");
+      return false;
+    }
+    
+    m_recreate = true; // Force recreation of context
+    Logger::info("XeSS: Activation successful");
+    return true;
+  }
+
+  void DxvkXeSS::onDeactivation() {
+    Logger::info("XeSS: Deactivating XeSS upscaler");
+    if (m_xessContext) {
+      destroyXeSSContext();
+    }
+    m_initialized = false;
+  }
+
+  void DxvkXeSS::createTargetResource(Rc<DxvkContext>& ctx, const VkExtent3D& targetExtent) {
+    // XeSS doesn't need additional target resources beyond what's managed internally
+    // This method is required by RtxPass but can be empty for XeSS
+  }
+
+  void DxvkXeSS::releaseTargetResource() {
+    // Release any target-specific resources if needed
+    // This method is required by RtxPass but can be empty for XeSS
+  }
+
+  bool DxvkXeSS::isXeSSLibraryAvailable() {
+    Logger::info("XeSS: Checking XeSS library availability...");
+    
+    // Try to get XeSS version to test if library is available
+    xess_version_t version;
+    xess_result_t result = xessGetVersion(&version);
+    
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info(str::format("XeSS: SDK version: ", version.major, ".", version.minor, ".", version.patch));
+      return true;
+    } else {
+      Logger::warn(str::format("XeSS: library not available: ", xessResultToString(result)));
+      return false;
+    }
+  }
+
+  bool DxvkXeSS::validateXeSSSupport(DxvkDevice* device) {
+    Logger::info("XeSS: Validating XeSS support...");
+    
+    if (!isXeSSLibraryAvailable()) {
+      return false;
+    }
+
+    // Get XeSS version
+    xess_version_t version;
+    xess_result_t result = xessGetVersion(&version);
+    if (result != XESS_RESULT_SUCCESS) {
+      Logger::warn(str::format("XeSS: Failed to get XeSS version: ", xessResultToString(result)));
+      return false;
+    }
+    
+    Logger::info(str::format("XeSS: SDK version: ", version.major, ".", version.minor, ".", version.patch));
+
+    // Check required instance extensions
+    uint32_t instanceExtCount = 0;
+    const char* const* instanceExtensions = nullptr;
+    uint32_t minVkApiVersion = 0;
+    
+    result = xessVKGetRequiredInstanceExtensions(&instanceExtCount, &instanceExtensions, &minVkApiVersion);
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info(str::format("XeSS: requires ", instanceExtCount, " instance extensions, min Vulkan API version: ", minVkApiVersion));
+      
+      // Log the required extensions
+      for (uint32_t i = 0; i < instanceExtCount; i++) {
+        Logger::info(str::format("XeSS: Required instance extension: ", instanceExtensions[i]));
+      }
+    } else {
+      Logger::warn(str::format("XeSS: Failed to get required instance extensions: ", xessResultToString(result)));
+    }
+
+    // Check required device extensions
+    uint32_t deviceExtCount = 0;
+    const char* const* deviceExtensions = nullptr;
+    
+    result = xessVKGetRequiredDeviceExtensions(
+      device->instance()->handle(),
+      device->adapter()->handle(),
+      &deviceExtCount,
+      &deviceExtensions
+    );
+    
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info(str::format("XeSS: requires ", deviceExtCount, " device extensions"));
+      
+      // Log the required extensions
+      for (uint32_t i = 0; i < deviceExtCount; i++) {
+        Logger::info(str::format("XeSS: Required device extension: ", deviceExtensions[i]));
+      }
+    } else {
+      Logger::warn(str::format("XeSS: Failed to get required device extensions: ", xessResultToString(result)));
+    }
+
+    // GPU compatibility check
+    auto adapter = device->adapter();
+    auto deviceProps = adapter->deviceProperties();
+    
+    if (deviceProps.vendorID == 0x8086) { // Intel
+      Logger::info("XeSS: Intel GPU detected - using optimized XeSS path");
+    } else {
+      Logger::info("XeSS: Non-Intel GPU detected - using generic XeSS path");
+    }
+
+    // Test context creation
+    xess_context_handle_t testContext = nullptr;
+    result = xessVKCreateContext(
+      device->instance()->handle(),
+      device->adapter()->handle(),
+      device->handle(),
+      &testContext
+    );
+    
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info("XeSS: context creation test successful");
+      // Clean up test context
+      xessDestroyContext(testContext);
+      return true;
+    } else {
+      Logger::warn(str::format("XeSS: context creation test failed: ", xessResultToString(result)));
+      return false;
+    }
+  }
+
+  xess_quality_settings_t DxvkXeSS::profileToQuality(XeSSProfile profile) const {
+    switch (profile) {
+      case XeSSProfile::UltraPerf: return XESS_QUALITY_SETTING_ULTRA_PERFORMANCE;
+      case XeSSProfile::Performance: return XESS_QUALITY_SETTING_PERFORMANCE;
+      case XeSSProfile::Balanced: return XESS_QUALITY_SETTING_BALANCED;
+      case XeSSProfile::Quality: return XESS_QUALITY_SETTING_QUALITY;
+      case XeSSProfile::UltraQuality: return XESS_QUALITY_SETTING_ULTRA_QUALITY;
+      case XeSSProfile::UltraQualityPlus: return XESS_QUALITY_SETTING_ULTRA_QUALITY_PLUS;
+      case XeSSProfile::NativeAA: return XESS_QUALITY_SETTING_AA;
+      case XeSSProfile::Custom: return XESS_QUALITY_SETTING_BALANCED; // Use balanced as base for custom
+      default: return XESS_QUALITY_SETTING_BALANCED;
+    }
+  }
+
+  VkExtent3D DxvkXeSS::getInputSize(const VkExtent3D& targetExtent) const {
+    if (!isEnabled() || !m_xessContext) {
+      return targetExtent;
+    }
+
+    XeSSProfile currentProfile = getProfile();
+    
+    if (currentProfile == XeSSProfile::Custom) {
+      // For Custom profile, use resolution scale directly
+      float scaleFactor = RtxOptions::resolutionScale();
+      VkExtent3D inputExtent;
+      inputExtent.width = std::max(1u, static_cast<uint32_t>(targetExtent.width * scaleFactor));
+      inputExtent.height = std::max(1u, static_cast<uint32_t>(targetExtent.height * scaleFactor));
+      inputExtent.depth = targetExtent.depth;
+      return inputExtent;
+    } else {
+      // Use XeSS SDK to get optimal input resolution for XeSS 2.1+ compliance
+      xess_2d_t targetRes = { static_cast<uint32_t>(targetExtent.width), static_cast<uint32_t>(targetExtent.height) };
+      xess_2d_t optimalInputRes = { 0, 0 };
+      xess_2d_t minInputRes = { 0, 0 };
+      xess_2d_t maxInputRes = { 0, 0 };
+      
+      xess_quality_settings_t quality = profileToQuality(currentProfile);
+      xess_result_t result = xessGetOptimalInputResolution(
+        m_xessContext, 
+        &targetRes, 
+        quality, 
+        &optimalInputRes, 
+        &minInputRes, 
+        &maxInputRes
+      );
+      
+      if (result == XESS_RESULT_SUCCESS) {
+        VkExtent3D inputExtent;
+        inputExtent.width = optimalInputRes.x;
+        inputExtent.height = optimalInputRes.y;
+        inputExtent.depth = targetExtent.depth;
+        
+        return inputExtent;
+      } else {
+        Logger::warn(str::format("XeSS 2.1: Failed to get optimal input resolution, using fallback: ", xessResultToString(result)));
+        // Fallback to hardcoded values
+        float scaleFactor = 1.0f / 2.0f; // Default to balanced
+        switch (quality) {
+          case XESS_QUALITY_SETTING_ULTRA_PERFORMANCE: scaleFactor = 1.0f / 3.0f; break;
+          case XESS_QUALITY_SETTING_PERFORMANCE:       scaleFactor = 1.0f / 2.3f; break;
+          case XESS_QUALITY_SETTING_BALANCED:          scaleFactor = 1.0f / 2.0f; break;
+          case XESS_QUALITY_SETTING_QUALITY:           scaleFactor = 1.0f / 1.7f; break;
+          case XESS_QUALITY_SETTING_ULTRA_QUALITY:     scaleFactor = 1.0f / 1.5f; break;
+          case XESS_QUALITY_SETTING_ULTRA_QUALITY_PLUS: scaleFactor = 1.0f / 1.3f; break;
+          case XESS_QUALITY_SETTING_AA:                scaleFactor = 1.0f; break;
+        }
+        
+        VkExtent3D inputExtent;
+        inputExtent.width = std::max(1u, static_cast<uint32_t>(targetExtent.width * scaleFactor));
+        inputExtent.height = std::max(1u, static_cast<uint32_t>(targetExtent.height * scaleFactor));
+        inputExtent.depth = targetExtent.depth;
+        return inputExtent;
+      }
+    }
+  }
+
+  void DxvkXeSS::initialize(Rc<DxvkContext> renderContext, const VkExtent3D& targetExtent) {
+    if (!isEnabled()) {
+      return;
+    }
+
+    // Check if we need to recreate the context
+    XeSSProfile currentProfile = getProfile();
+    if (m_initialized && 
+        m_targetExtent.width == targetExtent.width &&
+        m_targetExtent.height == targetExtent.height &&
+        m_currentProfile == currentProfile) {
+      return; // Already initialized with correct settings
+    }
+
+    // Release existing context if any
+    if (m_xessContext) {
+      destroyXeSSContext();
+    }
+
+    m_targetExtent = targetExtent;
+    m_inputExtent = getInputSize(targetExtent);
+    m_currentProfile = currentProfile;
+
+    createXeSSContext(targetExtent);
+    m_initialized = true;
+
+    Logger::info(str::format("XeSS: Initialized with input resolution ", m_inputExtent.width, "x", m_inputExtent.height, 
+                            " -> output resolution ", m_targetExtent.width, "x", m_targetExtent.height));
+  }
+
+  void DxvkXeSS::createXeSSContext(const VkExtent3D& targetExtent) {
+    Logger::info("XeSS: Creating XeSS context...");
+    
+    if (!m_device) {
+      Logger::err("XeSS: Cannot create context - no device available");
+      return;
+    }
+    
+    // Create XeSS context using real SDK
+    xess_result_t     result = xessVKCreateContext(
+      m_device->instance()->handle(),
+      m_device->adapter()->handle(),
+      m_device->handle(),
+      &m_xessContext
+    );
+    
+    if (result != XESS_RESULT_SUCCESS) {
+      Logger::err(str::format("XeSS: Failed to create context: ", xessResultToString(result)));
+      m_xessContext = nullptr;
+      return;
+    }
+    
+    Logger::info("XeSS: Context created successfully");
+    
+    xess_quality_settings_t quality = profileToQuality(m_currentProfile);
+    xess_init_flags_t preFlags = XESS_INIT_FLAG_NONE;
+    
+    // Trigger pre-build in background to reduce later initialization stalls
+    result = xessVKBuildPipelines(m_xessContext, VK_NULL_HANDLE, false, preFlags);
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info("XeSS 2.1: Pipeline pre-build initiated");
+    } else {
+      Logger::warn(str::format("XeSS 2.1: Pipeline pre-build failed, will compile during init: ", xessResultToString(result)));
+    }
+    
+    // XeSS 2.1: Verify driver compatibility and warn if suboptimal
+    xess_result_t driverResult = xessIsOptimalDriver(m_xessContext);
+    if (driverResult == XESS_RESULT_WARNING_OLD_DRIVER) {
+      Logger::warn("XeSS 2.1: Using older driver - update recommended for optimal performance and quality");
+      // In a real application, you might want to show a user-facing notification here
+    } else if (driverResult == XESS_RESULT_SUCCESS) {
+      Logger::info("XeSS 2.1: Driver version verified as optimal");
+    } else {
+      Logger::warn(str::format("XeSS 2.1: Driver verification returned: ", xessResultToString(driverResult)));
+    }
+    
+    // Always use KPSS network model (best quality)
+    result = xessSelectNetworkModel(m_xessContext, XESS_NETWORK_MODEL_KPSS);
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info("XeSS: Selected KPSS network model");
+    } else {
+      Logger::warn(str::format("XeSS: Failed to select KPSS network model: ", xessResultToString(result)));
+    }
+    
+    // XeSS 2.1: Set responsive pixel mask clamp value if different from default
+    float responsiveMaskClamp = RtxOptions::xessResponsivePixelMaskClampValue();
+    if (responsiveMaskClamp != 0.8f) { // Only set if different from XeSS default
+      result = xessSetMaxResponsiveMaskValue(m_xessContext, responsiveMaskClamp);
+      if (result == XESS_RESULT_SUCCESS) {
+        Logger::info(str::format("XeSS 2.1: Set responsive pixel mask clamp value to ", responsiveMaskClamp));
+      } else {
+        Logger::warn(str::format("XeSS 2.1: Failed to set responsive pixel mask clamp value: ", xessResultToString(result)));
+      }
+    }
+    
+    // Get and log XeSS jitter scale for debugging
+    float jitterScaleX, jitterScaleY;
+    result = xessGetJitterScale(m_xessContext, &jitterScaleX, &jitterScaleY);
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info(str::format("XeSS: Default jitter scale: ", jitterScaleX, "x", jitterScaleY));
+    }
+    
+    // Get and log XeSS velocity scale for debugging  
+    float velocityScaleX, velocityScaleY;
+    result = xessGetVelocityScale(m_xessContext, &velocityScaleX, &velocityScaleY);
+    if (result == XESS_RESULT_SUCCESS) {
+      Logger::info(str::format("XeSS: Default velocity scale: ", velocityScaleX, "x", velocityScaleY));
+    }
+    
+    // Initialize XeSS with current settings
+    xess_vk_init_params_t initParams = {};
+    initParams.outputResolution.x = targetExtent.width;
+    initParams.outputResolution.y = targetExtent.height;
+    initParams.qualitySetting = profileToQuality(m_currentProfile);
+
+    // Set initialization flags based on renderer state and user options
+    initParams.initFlags = XESS_INIT_FLAG_NONE;
+
+    // Always use Remix's exposure texture - it works best
+    Logger::info("XeSS: Using Remix exposure texture");
+    m_isUsingInternalAutoExposure = false;
+    
+    initParams.creationNodeMask = 1;
+    initParams.visibleNodeMask = 1;
+    initParams.tempBufferHeap = VK_NULL_HANDLE;
+    initParams.bufferHeapOffset = 0;
+    initParams.tempTextureHeap = VK_NULL_HANDLE;
+    initParams.textureHeapOffset = 0;
+    initParams.pipelineCache = VK_NULL_HANDLE;
+    
+    result = xessVKInit(m_xessContext, &initParams);
+    if (result != XESS_RESULT_SUCCESS) {
+      Logger::err(str::format("XeSS: Failed to initialize context: ", xessResultToString(result)));
+      xessDestroyContext(m_xessContext);
+      m_xessContext = nullptr;
+      return;
+    }
+    
+    Logger::info("XeSS: Context initialized successfully");
+  }
+
+  uint32_t DxvkXeSS::calculateRecommendedJitterSequenceLength() const {
+    if (!RtxOptions::xessUseRecommendedJitterSequenceLength()) {
+      return RtxOptions::cameraJitterSequenceLength(); // Use global setting
+    }
+    
+    // XeSS 2.1 formula: ceil(upscale_factor^2 * 8)
+    // For extreme scaling (e.g. 0.10x = 10x upscaling), this ensures sufficient temporal samples
+    float scaleFactor = 1.0f;
+    XeSSProfile currentProfile = getProfile();
+    
+    if (currentProfile == XeSSProfile::Custom) {
+      scaleFactor = 1.0f / RtxOptions::resolutionScale();
+    } else {
+      xess_quality_settings_t quality = profileToQuality(currentProfile);
+      switch (quality) {
+        case XESS_QUALITY_SETTING_ULTRA_PERFORMANCE: scaleFactor = 3.0f; break;
+        case XESS_QUALITY_SETTING_PERFORMANCE:       scaleFactor = 2.3f; break;
+        case XESS_QUALITY_SETTING_BALANCED:          scaleFactor = 2.0f; break;
+        case XESS_QUALITY_SETTING_QUALITY:           scaleFactor = 1.7f; break;
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY:     scaleFactor = 1.5f; break;
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY_PLUS: scaleFactor = 1.3f; break;
+        case XESS_QUALITY_SETTING_AA:                scaleFactor = 1.0f; break;
+        default:                                      scaleFactor = 2.0f; break;
+      }
+    }
+    
+    uint32_t recommendedLength = static_cast<uint32_t>(std::ceil(scaleFactor * scaleFactor * 8.0f));
+    
+    // Expanded range: minimum of 8, maximum of 1024 for extreme scaling scenarios
+    recommendedLength = std::clamp(recommendedLength, 8u, 1024u);
+    
+    return recommendedLength;
+  }
+
+  float DxvkXeSS::calculateRecommendedMipBias() const {
+    // XeSS 2.1 formula: -log2(upscale_factor)
+    float scaleFactor = 1.0f;
+    XeSSProfile currentProfile = getProfile();
+    
+    if (currentProfile == XeSSProfile::Custom) {
+      scaleFactor = 1.0f / RtxOptions::resolutionScale();
+    } else {
+      xess_quality_settings_t quality = profileToQuality(currentProfile);
+      switch (quality) {
+        case XESS_QUALITY_SETTING_ULTRA_PERFORMANCE: scaleFactor = 3.0f; break;
+        case XESS_QUALITY_SETTING_PERFORMANCE:       scaleFactor = 2.3f; break;
+        case XESS_QUALITY_SETTING_BALANCED:          scaleFactor = 2.0f; break;
+        case XESS_QUALITY_SETTING_QUALITY:           scaleFactor = 1.7f; break;
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY:     scaleFactor = 1.5f; break;
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY_PLUS: scaleFactor = 1.3f; break;
+        case XESS_QUALITY_SETTING_AA:                scaleFactor = 1.0f; break;
+        default:                                      scaleFactor = 2.0f; break;
+      }
+    }
+    
+    float mipBias = -std::log2(scaleFactor);
+
+    return mipBias;
+  }
+
+  void DxvkXeSS::destroyXeSSContext() {
+    if (m_xessContext) {
+      Logger::info("XeSS: Destroying XeSS context");
+      xess_result_t result = xessDestroyContext(m_xessContext);
+      if (result != XESS_RESULT_SUCCESS) {
+        Logger::warn(str::format("XeSS: Warning during context destruction: ", xessResultToString(result)));
+      }
+      m_xessContext = nullptr;
+    }
+  }
+
+  void DxvkXeSS::dispatch(
+    Rc<DxvkContext> renderContext,
+    DxvkBarrierSet& barriers,
+    const Resources::RaytracingOutput& rtOutput,
+    bool resetHistory) {
+    
+    if (!isEnabled()) {
+      // Fallback: just copy input to output
+      renderContext->copyImage(
+        rtOutput.m_finalOutput.resource(Resources::AccessType::Write).image,
+        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        { 0, 0, 0 },
+        rtOutput.m_compositeOutput.image(Resources::AccessType::Read),
+        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        { 0, 0, 0 },
+        rtOutput.m_compositeOutputExtent);
+      return;
+    }
+
+    // Initialize XeSS if needed (similar to DLSS pattern)
+    if (m_recreate || !m_initialized) {
+      // Use the target extent that was already calculated in setSetting()
+      // If setSetting() hasn't been called yet (e.g., Auto preset on first load), 
+      // fall back to the actual output texture resolution
+      VkExtent3D targetExtent;
+      if (m_xessOutputSize.width > 0 && m_xessOutputSize.height > 0) {
+        targetExtent = { 
+          m_xessOutputSize.width,
+          m_xessOutputSize.height,
+          1
+        };
+      } else {
+        // Fallback to actual output texture resolution
+        targetExtent = { 
+          rtOutput.m_finalOutput.resource(Resources::AccessType::Write).image->info().extent.width,
+          rtOutput.m_finalOutput.resource(Resources::AccessType::Write).image->info().extent.height,
+          1
+        };
+      }
+      initialize(renderContext, targetExtent);
+      m_recreate = false;
+    }
+
+    if (!m_initialized || !m_xessContext) {
+      // Fallback: just copy input to output
+      renderContext->copyImage(
+        rtOutput.m_finalOutput.resource(Resources::AccessType::Write).image,
+        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        { 0, 0, 0 },
+        rtOutput.m_compositeOutput.image(Resources::AccessType::Read),
+        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        { 0, 0, 0 },
+        rtOutput.m_compositeOutputExtent);
+      return;
+    }
+    
+    // Set up image barriers for XeSS inputs and outputs
+    std::vector<Rc<DxvkImageView>> inputs = {
+      rtOutput.m_compositeOutput.view(Resources::AccessType::Read),
+      rtOutput.m_primaryScreenSpaceMotionVector.view,
+      rtOutput.m_primaryDepth.view
+    };
+
+    auto& autoExposure = m_device->getCommon()->metaAutoExposure();
+    if (autoExposure.enabled() && autoExposure.getExposureTexture().image != nullptr) {
+      inputs.push_back(autoExposure.getExposureTexture().view);
+    }
+
+    std::vector<Rc<DxvkImageView>> outputs = {
+      rtOutput.m_finalOutput.view(Resources::AccessType::Write)
+    };
+
+    // Set up barriers for input textures
+    for (auto input : inputs) {
+      if (input == nullptr) {
+        continue;
+      }
+      
+      barriers.accessImage(
+        input->image(),
+        input->imageSubresources(),
+        input->imageInfo().layout,
+        input->imageInfo().stages,
+        input->imageInfo().access,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_ACCESS_SHADER_READ_BIT);
+    }
+
+    // Set up barriers for output texture
+    for (auto output : outputs) {
+      barriers.accessImage(
+        output->image(),
+        output->imageSubresources(),
+        output->imageInfo().layout,
+        output->imageInfo().stages,
+        output->imageInfo().access,
+        VK_IMAGE_LAYOUT_GENERAL,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_ACCESS_SHADER_WRITE_BIT);
+    }
+
+    barriers.recordCommands(renderContext->getCommandList());
+
+    // Get jitter offset from camera
+    auto& sceneManager = m_device->getCommon()->getSceneManager();
+    RtCamera& camera = sceneManager.getCamera();
+    float jitterOffset[2];
+    camera.getJittering(jitterOffset);
+
+    // XeSS expects jitter in the range [-0.5, 0.5] in pixel units
+    // The camera jitter is already in pixel units, so we can use it directly
+    // However, we need to ensure it's properly scaled for XeSS
+    float xessJitterX = jitterOffset[0];
+    float xessJitterY = jitterOffset[1];
+    
+    if (RtxOptions::xessUseOptimizedJitter()) {
+      // Get XeSS jitter scale to understand expected range
+      float jitterScaleX, jitterScaleY;
+      xess_result_t scaleResult = xessGetJitterScale(m_xessContext, &jitterScaleX, &jitterScaleY);
+      if (scaleResult == XESS_RESULT_SUCCESS) {
+        // Apply XeSS jitter scale if available
+        xessJitterX *= jitterScaleX;
+        xessJitterY *= jitterScaleY;
+        
+        // Applied jitter scale - debug logging removed to avoid spam
+      }
+    }
+    
+    // Apply user jitter scale multiplier
+    float userJitterScale = RtxOptions::xessJitterScale();
+    
+    // Apply adaptive jitter scaling for extreme upscaling scenarios
+    if (RtxOptions::xessUseOptimizedJitter()) {
+      XeSSProfile profile = getProfile();
+      float scaleFactor = 1.0f;
+      
+      if (profile == XeSSProfile::Custom) {
+        scaleFactor = 1.0f / RtxOptions::resolutionScale();
+      } else {
+        xess_quality_settings_t quality = profileToQuality(m_actualProfile);
+        switch (quality) {
+        case XESS_QUALITY_SETTING_ULTRA_PERFORMANCE: scaleFactor = 3.0f; break;
+        case XESS_QUALITY_SETTING_PERFORMANCE: scaleFactor = 2.3f; break;
+        case XESS_QUALITY_SETTING_BALANCED: scaleFactor = 2.0f; break;
+        case XESS_QUALITY_SETTING_QUALITY: scaleFactor = 1.7f; break;
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY: scaleFactor = 1.5f; break;
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY_PLUS: scaleFactor = 1.3f; break;
+        case XESS_QUALITY_SETTING_AA: scaleFactor = 1.0f; break;
+        default: scaleFactor = 2.0f; break;
+        }
+      }
+      
+      // Adaptive jitter scaling to reduce swimming artifacts at extreme scaling
+      if (scaleFactor > 6.0f) {
+        // Extreme scaling (e.g., 0.10x resolution = 10x upscaling): configurable jitter reduction
+        float extremeDamping = RtxOptions::xessScalingJitterDamping();
+        userJitterScale *= extremeDamping;
+        // Extreme scaling detected - debug logging removed to avoid spam
+      } else if (scaleFactor > 4.0f) {
+        // Very high scaling: moderate jitter reduction
+        userJitterScale *= 0.75f;
+      } else if (scaleFactor > 2.5f) {
+        // High scaling: light jitter reduction
+        userJitterScale *= 0.85f;
+      }
+    }
+    
+    xessJitterX *= userJitterScale;
+    xessJitterY *= userJitterScale;
+    
+    // Clamp jitter to XeSS expected range [-0.5, 0.5]
+    xessJitterX = std::clamp(xessJitterX, -0.5f, 0.5f);
+    xessJitterY = std::clamp(xessJitterY, -0.5f, 0.5f);
+
+    // Set up XeSS execution parameters
+    xess_vk_execute_params_t execParams = {};
+    
+    // Input color texture
+    auto colorView = rtOutput.m_compositeOutput.view(Resources::AccessType::Read);
+    execParams.colorTexture.imageView = colorView->handle();
+    execParams.colorTexture.image = colorView->image()->handle();
+    execParams.colorTexture.subresourceRange = colorView->subresources();
+    execParams.colorTexture.format = colorView->info().format;
+    execParams.colorTexture.width = colorView->imageInfo().extent.width;
+    execParams.colorTexture.height = colorView->imageInfo().extent.height;
+
+    // Optional Exposure texture
+    if (autoExposure.enabled() && autoExposure.getExposureTexture().image != nullptr) {
+      auto exposureView = autoExposure.getExposureTexture().view;
+      execParams.exposureScaleTexture.imageView = exposureView->handle();
+      execParams.exposureScaleTexture.image = exposureView->image()->handle();
+      execParams.exposureScaleTexture.subresourceRange = exposureView->subresources();
+      execParams.exposureScaleTexture.format = exposureView->info().format;
+      execParams.exposureScaleTexture.width = exposureView->imageInfo().extent.width;
+      execParams.exposureScaleTexture.height = exposureView->imageInfo().extent.height;
+    } else {
+      // Zero out the struct if not used
+      memset(&execParams.exposureScaleTexture, 0, sizeof(execParams.exposureScaleTexture));
+    }
+
+    // Motion vector texture
+    auto motionView = rtOutput.m_primaryScreenSpaceMotionVector.view;
+    execParams.velocityTexture.imageView = motionView->handle();
+    execParams.velocityTexture.image = motionView->image()->handle();
+    execParams.velocityTexture.subresourceRange = motionView->subresources();
+    execParams.velocityTexture.format = motionView->info().format;
+    execParams.velocityTexture.width = motionView->imageInfo().extent.width;
+    execParams.velocityTexture.height = motionView->imageInfo().extent.height;
+
+    // Depth texture
+    auto depthView = rtOutput.m_primaryDepth.view;
+    execParams.depthTexture.imageView = depthView->handle();
+    execParams.depthTexture.image = depthView->image()->handle();
+    execParams.depthTexture.subresourceRange = depthView->subresources();
+    execParams.depthTexture.format = depthView->info().format;
+    execParams.depthTexture.width = depthView->imageInfo().extent.width;
+    execParams.depthTexture.height = depthView->imageInfo().extent.height;
+
+    // Output texture
+    auto outputView = rtOutput.m_finalOutput.view(Resources::AccessType::Write);
+    execParams.outputTexture.imageView = outputView->handle();
+    execParams.outputTexture.image = outputView->image()->handle();
+    execParams.outputTexture.subresourceRange = outputView->subresources();
+    execParams.outputTexture.format = outputView->info().format;
+    execParams.outputTexture.width = outputView->imageInfo().extent.width;
+    execParams.outputTexture.height = outputView->imageInfo().extent.height;
+
+    // Always provide jitter separately as calculated above
+    execParams.jitterOffsetX = xessJitterX;
+    execParams.jitterOffsetY = xessJitterY;
+
+    execParams.exposureScale = 1.0f; // Default exposure scale
+    execParams.resetHistory = resetHistory ? 1 : 0;
+    // Use the input size from setSetting for all profiles
+    execParams.inputWidth = m_inputSize.width;
+    execParams.inputHeight = m_inputSize.height;
+    
+    // Base coordinates (default to 0,0)
+    execParams.inputColorBase = { 0, 0 };
+    execParams.inputMotionVectorBase = { 0, 0 };
+    execParams.inputDepthBase = { 0, 0 };
+    execParams.inputResponsiveMaskBase = { 0, 0 };
+    execParams.outputColorBase = { 0, 0 };
+
+    // Execute XeSS
+    VkCommandBuffer cmdBuffer = renderContext->getCommandList()->getCmdBuffer(DxvkCmdBuffer::ExecBuffer);
+    xess_result_t result = xessVKExecute(m_xessContext, cmdBuffer, &execParams);
+    
+    if (result != XESS_RESULT_SUCCESS) {
+      Logger::warn(str::format("XeSS: Execute failed: ", xessResultToString(result)));
+      
+      // Fallback to simple copy on failure
+      renderContext->copyImage(
+        rtOutput.m_finalOutput.resource(Resources::AccessType::Write).image,
+        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        { 0, 0, 0 },
+        rtOutput.m_compositeOutput.image(Resources::AccessType::Read),
+        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 },
+        { 0, 0, 0 },
+        rtOutput.m_compositeOutputExtent);
+    } else {
+      // XeSS execution successful - removed debug logging to avoid spam
+    }
+
+    // Restore barriers for output texture
+    for (auto output : outputs) {
+      barriers.accessImage(
+        output->image(),
+        output->imageSubresources(),
+        VK_IMAGE_LAYOUT_GENERAL,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_ACCESS_SHADER_WRITE_BIT,
+        output->imageInfo().layout,
+        output->imageInfo().stages,
+        output->imageInfo().access);
+
+      renderContext->getCommandList()->trackResource<DxvkAccess::None>(output);
+      renderContext->getCommandList()->trackResource<DxvkAccess::Write>(output->image());
+    }
+    
+    barriers.recordCommands(renderContext->getCommandList());
+  }
+
+  XeSSProfile DxvkXeSS::getAutoProfile(uint32_t displayWidth, uint32_t displayHeight) {
+    XeSSProfile desiredProfile = XeSSProfile::UltraPerf;
+
+    // Standard display resolution based XeSS config
+    if (displayHeight <= 1080) {
+      desiredProfile = XeSSProfile::Quality;
+    } else if (displayHeight < 2160) {
+      desiredProfile = XeSSProfile::Balanced;
+    } else if (displayHeight < 4320) {
+      desiredProfile = XeSSProfile::Performance;
+    } else {
+      // For > 4k (e.g. 8k)
+      desiredProfile = XeSSProfile::UltraPerf;
+    }
+
+    if (RtxOptions::graphicsPreset() == GraphicsPreset::Medium) {
+      // When using medium preset, bias XeSS more towards performance
+      desiredProfile = (XeSSProfile)std::max(0, (int) desiredProfile - 1);
+    } else if (RtxOptions::graphicsPreset() == GraphicsPreset::Low) {
+      // When using low preset, give me all the perf I can get!!!
+      desiredProfile = (XeSSProfile) std::max(0, (int) desiredProfile - 2);
+    }
+
+    return desiredProfile;
+  }
+
+  void DxvkXeSS::setSetting(const uint32_t displaySize[2], const XeSSProfile profile, uint32_t outRenderSize[2]) {
+    ScopedCpuProfileZone();
+    
+    // Use the profile directly (Auto preset removed)
+    XeSSProfile actualProfile = profile;
+
+    // For Custom profile, also check if resolution scale has changed
+    bool resolutionScaleChanged = false;
+    if (actualProfile == XeSSProfile::Custom) {
+      float currentScale = RtxOptions::resolutionScale();
+      resolutionScaleChanged = (currentScale != m_lastResolutionScale);
+      m_lastResolutionScale = currentScale;
+    }
+    
+    if (m_actualProfile == actualProfile && 
+        displaySize[0] == m_xessOutputSize.width && 
+        displaySize[1] == m_xessOutputSize.height &&
+        !resolutionScaleChanged) {
+      // Nothing changed that would alter XeSS resolution(s), so return the last cached optimal render size
+      outRenderSize[0] = m_inputSize.width;
+      outRenderSize[1] = m_inputSize.height;
+      return;
+    }
+    
+    m_actualProfile = actualProfile;
+    m_recreate = true;
+    m_profile = profile;
+    
+
+
+    if (m_profile == XeSSProfile::NativeAA) {
+      m_inputSize.width = outRenderSize[0] = displaySize[0];
+      m_inputSize.height = outRenderSize[1] = displaySize[1];
+    } else if (m_profile == XeSSProfile::Custom) {
+      // Use resolution scale for custom profile
+      float scale = RtxOptions::resolutionScale();
+      m_inputSize.width = outRenderSize[0] = std::max(1u, (uint32_t)(displaySize[0] * scale));
+      m_inputSize.height = outRenderSize[1] = std::max(1u, (uint32_t)(displaySize[1] * scale));
+    } else {
+      // Calculate optimal input resolution based on quality setting
+      xess_2d_t outputRes = { displaySize[0], displaySize[1] };
+      xess_2d_t inputRes;
+      
+      xess_quality_settings_t quality = profileToQuality(m_actualProfile);
+      
+      // Use XeSS SDK to get optimal input resolution
+      if (m_xessContext) {
+        xess_result_t result = xessGetOptimalInputResolution(m_xessContext, &outputRes, quality, &inputRes, nullptr, nullptr);
+        if (result == XESS_RESULT_SUCCESS) {
+          m_inputSize.width = outRenderSize[0] = inputRes.x;
+          m_inputSize.height = outRenderSize[1] = inputRes.y;
+        } else {
+          // Fallback to manual calculation using correct XeSS 1.3+ scaling factors
+          float scale = 1.0f;
+          switch (quality) {
+          case XESS_QUALITY_SETTING_ULTRA_PERFORMANCE: scale = 1.0f / 3.0f; break;   // 3.0x upscaling
+          case XESS_QUALITY_SETTING_PERFORMANCE: scale = 1.0f / 2.3f; break;        // 2.3x upscaling
+          case XESS_QUALITY_SETTING_BALANCED: scale = 1.0f / 2.0f; break;           // 2.0x upscaling
+          case XESS_QUALITY_SETTING_QUALITY: scale = 1.0f / 1.7f; break;            // 1.7x upscaling
+          case XESS_QUALITY_SETTING_ULTRA_QUALITY: scale = 1.0f / 1.5f; break;      // 1.5x upscaling
+          case XESS_QUALITY_SETTING_ULTRA_QUALITY_PLUS: scale = 1.0f / 1.3f; break; // 1.3x upscaling
+          case XESS_QUALITY_SETTING_AA: scale = 1.0f; break;                        // 1.0x (native)
+          default: scale = 1.0f / 2.0f; break;                                      // Default to balanced
+          }
+          m_inputSize.width = outRenderSize[0] = std::max(1u, (uint32_t)(displaySize[0] * scale));
+          m_inputSize.height = outRenderSize[1] = std::max(1u, (uint32_t)(displaySize[1] * scale));
+        }
+      } else {
+        // Fallback calculation when no context available yet using correct XeSS 1.3+ scaling factors
+        float scale = 1.0f;
+        switch (quality) {
+        case XESS_QUALITY_SETTING_ULTRA_PERFORMANCE: scale = 1.0f / 3.0f; break;   // 3.0x upscaling
+        case XESS_QUALITY_SETTING_PERFORMANCE: scale = 1.0f / 2.3f; break;        // 2.3x upscaling
+        case XESS_QUALITY_SETTING_BALANCED: scale = 1.0f / 2.0f; break;           // 2.0x upscaling
+        case XESS_QUALITY_SETTING_QUALITY: scale = 1.0f / 1.7f; break;            // 1.7x upscaling
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY: scale = 1.0f / 1.5f; break;      // 1.5x upscaling
+        case XESS_QUALITY_SETTING_ULTRA_QUALITY_PLUS: scale = 1.0f / 1.3f; break; // 1.3x upscaling
+        case XESS_QUALITY_SETTING_AA: scale = 1.0f; break;                        // 1.0x (native)
+        default: scale = 1.0f / 2.0f; break;                                      // Default to balanced
+        }
+        m_inputSize.width = outRenderSize[0] = std::max(1u, (uint32_t)(displaySize[0] * scale));
+        m_inputSize.height = outRenderSize[1] = std::max(1u, (uint32_t)(displaySize[1] * scale));
+      }
+    }
+
+    m_xessOutputSize.width = displaySize[0];
+    m_xessOutputSize.height = displaySize[1];
+    
+    // Update the camera system with the current upscaling ratio for dynamic jitter calculation
+    float currentUpscalingRatio = (float)displaySize[0] / (float)m_inputSize.width;
+    RtCamera::setCurrentUpscalingRatio(currentUpscalingRatio);
+  }
+
+  XeSSProfile DxvkXeSS::getCurrentProfile() const {
+    return m_actualProfile;
+  }
+
+  void DxvkXeSS::getInputSize(uint32_t& width, uint32_t& height) const {
+    width = m_inputSize.width;
+    height = m_inputSize.height;
+  }
+
+  void DxvkXeSS::getOutputSize(uint32_t& width, uint32_t& height) const {
+    width = m_xessOutputSize.width;
+    height = m_xessOutputSize.height;
+  }
+
+  XeSSProfile DxvkXeSS::getAutoProfile() const {
+    // Use the resolution-based auto profile selection with current output size
+    uint32_t displayWidth = m_xessOutputSize.width > 0 ? m_xessOutputSize.width : 1920;
+    uint32_t displayHeight = m_xessOutputSize.height > 0 ? m_xessOutputSize.height : 1080;
+    
+    XeSSProfile desiredProfile = XeSSProfile::UltraPerf;
+
+    // Standard display resolution based XeSS config
+    if (displayHeight <= 1080) {
+      desiredProfile = XeSSProfile::Quality;
+    } else if (displayHeight < 2160) {
+      desiredProfile = XeSSProfile::Balanced;
+    } else if (displayHeight < 4320) {
+      desiredProfile = XeSSProfile::Performance;
+    } else {
+      // For > 4k (e.g. 8k)
+      desiredProfile = XeSSProfile::UltraPerf;
+    }
+
+    if (RtxOptions::graphicsPreset() == GraphicsPreset::Medium) {
+      // When using medium preset, bias XeSS more towards performance
+      desiredProfile = (XeSSProfile)std::max(0, (int) desiredProfile - 1);
+    } else if (RtxOptions::graphicsPreset() == GraphicsPreset::Low) {
+      // When using low preset, give me all the perf I can get!!!
+      desiredProfile = (XeSSProfile) std::max(0, (int) desiredProfile - 2);
+    }
+
+    return desiredProfile;
+  }
+
+  void DxvkXeSS::setSetting(const char* name, const char* value) {
+  }
+} 

--- a/src/dxvk/rtx_render/rtx_xess.h
+++ b/src/dxvk/rtx_render/rtx_xess.h
@@ -1,0 +1,126 @@
+/*
+* Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+* DEALINGS IN THE SOFTWARE.
+*/
+#pragma once
+
+#include "rtx_resources.h"
+#include "rtx_options.h"
+
+#include "../dxvk_format.h"
+#include "../dxvk_include.h"
+#include "../util/rc/util_rc.h"
+#include "../util/rc/util_rc_ptr.h"
+
+#include "../../../external/xess/inc/xess/xess.h"
+#include "../../../external/xess/inc/xess/xess_vk.h"
+
+namespace dxvk {
+
+  class DxvkDevice;
+
+  /**
+   * \brief XeSS upscaler
+   * 
+   * Intel XeSS Super Resolution implementation following RtxPass architecture
+   */
+  class DxvkXeSS : public RtxPass {
+
+  public:
+
+    // Constructor with device
+    DxvkXeSS(DxvkDevice* device);
+
+    ~DxvkXeSS();
+
+    void initialize(Rc<DxvkContext> renderContext, const VkExtent3D& targetExtent);
+
+    VkExtent3D getInputSize(const VkExtent3D& targetExtent) const;
+    
+    void dispatch(
+      Rc<DxvkContext> renderContext,
+      DxvkBarrierSet& barriers,
+      const Resources::RaytracingOutput& rtOutput,
+      bool resetHistory);
+
+    static XeSSProfile getProfile() { return RtxOptions::xessProfile(); }
+
+    // Public methods needed by RTX context
+    void setSetting(const uint32_t displaySize[2], const XeSSProfile profile, uint32_t outRenderSize[2]);
+    void getInputSize(uint32_t& width, uint32_t& height) const;
+    
+    // XeSS 2.1 public helper methods
+    uint32_t getRecommendedJitterSequenceLength() const { return calculateRecommendedJitterSequenceLength(); }
+    float getRecommendedMipBias() const { return calculateRecommendedMipBias(); }
+    
+    // Public accessor for external components
+    bool isXeSSEnabled() const { return isEnabled(); }
+
+  protected:
+
+    // RtxPass interface
+    virtual bool isEnabled() const override;
+    virtual bool onActivation(Rc<DxvkContext>& ctx) override;
+    virtual void onDeactivation() override;
+    virtual void createTargetResource(Rc<DxvkContext>& ctx, const VkExtent3D& targetExtent) override;
+    virtual void releaseTargetResource() override;
+
+  private:
+
+    // XeSS 2.1 helper functions
+    uint32_t calculateRecommendedJitterSequenceLength() const;
+    float calculateRecommendedMipBias() const;
+
+    void createXeSSContext(const VkExtent3D& targetExtent);
+    void destroyXeSSContext();
+    bool validateXeSSSupport(DxvkDevice* device);
+    
+    // Additional methods needed by implementation
+    XeSSProfile getAutoProfile() const;
+    XeSSProfile getAutoProfile(uint32_t displayWidth, uint32_t displayHeight);
+    XeSSProfile getCurrentProfile() const;
+    void setSetting(const char* name, const char* value);
+    void getOutputSize(uint32_t& width, uint32_t& height) const;
+    xess_quality_settings_t profileToQuality(XeSSProfile profile) const;
+    
+    // Static helper to check if XeSS library is available at all
+    static bool isXeSSLibraryAvailable();
+
+    // Member variables - organized after methods per style guide
+    DxvkDevice* m_device;  // Need direct device access for XeSS operations
+    bool m_initialized;
+    xess_context_handle_t m_xessContext;
+    VkExtent3D m_targetExtent;
+    VkExtent3D m_inputExtent;
+    XeSSProfile m_currentProfile;
+    
+    bool m_isUsingInternalAutoExposure;
+
+    // Additional member variables needed by implementation
+    xess_context_handle_t m_context;
+    XeSSProfile m_profile;
+    XeSSProfile m_actualProfile;
+    VkExtent2D m_inputSize;
+    VkExtent2D m_xessOutputSize;
+    bool m_recreate;
+    float m_lastResolutionScale; // Track resolution scale changes for Custom profile
+  };
+
+}

--- a/src/dxvk/shaders/rtx/concept/camera/camera.h
+++ b/src/dxvk/shaders/rtx/concept/camera/camera.h
@@ -34,6 +34,7 @@ struct Camera
   mat4 projectionToView;
   mat4 viewToProjectionJittered;
   mat4 projectionToViewJittered;
+  mat4 worldToProjection;
   mat4 worldToProjectionJittered;
   mat4 projectionToWorldJittered;
   mat4 translatedWorldToView;
@@ -62,6 +63,7 @@ struct VolumeDefinitionCamera
 {
   mat4 viewToProjection;
   mat4 translatedWorldToView;
+  mat4 translatedWorldToProjection;
   mat4 translatedWorldToProjectionJittered;
   mat4 projectionToTranslatedWorld;
   mat4 prevTranslatedWorldToView;

--- a/src/dxvk/shaders/rtx/pass/raytrace_args.h
+++ b/src/dxvk/shaders/rtx/pass/raytrace_args.h
@@ -383,6 +383,8 @@ struct RaytraceArgs {
   float vertexColorStrength;
   uint vertexColorIsBakedLighting;
 
+  uint3 pad_xess;
+
   // NOTE: Add structs to the top section of RaytraceArgs, not the bottom.
   // NOTE: bool does not work in debug builds, use uint instead.
 };


### PR DESCRIPTION
Adding another upscaling backend for users who don't have NVIDIA hardware but want a higher quality solution compared to TAA-U.

This implementation relies on Intel's XeSS SDK, so upscaler binaries like `libxess.dll` will need to be distributed with CI builds/Releases. They can be found in the [XeSS SDK repo in `xess/bin`](https://github.com/intel/xess/tree/main/bin)

### Visual Comparison
(AMD RX 9070 @ 4K)
https://imgsli.com/Mzg4OTYz

EDIT: Turning this back into a draft as the image is not as temporally stable as it should be.