### PR TITLE
Add AgX Tonemapper

### DIFF
--- a/src/dxvk/rtx_render/rtx_local_tone_mapping.h
+++ b/src/dxvk/rtx_render/rtx_local_tone_mapping.h
@@ -75,6 +75,14 @@ namespace dxvk {
     RTX_OPTION("rtx.localtonemap", bool, boostLocalContrast, false, "Boosts contrast on local features.");
     RTX_OPTION("rtx.localtonemap", bool, useGaussian, true, "Uses gaussian kernel to generate tone map pyramid.");
     RTX_OPTION("rtx.localtonemap", bool, finalizeWithACES, true, "Applies ACES tone mapping on final result.");
+    RTX_OPTION("rtx.localtonemap", bool, useAgX, false, "Applies AgX tone mapping instead of ACES on final result.");
+    RTX_OPTION("rtx.localtonemap", float, agxGamma, 0.45f, "AgX gamma adjustment for contrast control. Lower values increase contrast. Range [0.5, 3.0].");
+    RTX_OPTION("rtx.localtonemap", float, agxSaturation, 1.0f, "AgX saturation multiplier. Higher values increase color saturation. Range [0.5, 2.0].");
+    RTX_OPTION("rtx.localtonemap", float, agxExposureOffset, 0.0f, "AgX exposure offset in EV stops. Positive values brighten the image. Range [-2.0, 2.0].");
+    RTX_OPTION("rtx.localtonemap", int, agxLook, 0, "AgX look selection: 0=None, 1=Punchy, 2=Golden, 3=Greyscale. Different aesthetic looks for AgX.");
+    RTX_OPTION("rtx.localtonemap", float, agxContrast, 0.8f, "AgX contrast adjustment. Higher values increase contrast. Range [0.5, 2.0].");
+    RTX_OPTION("rtx.localtonemap", float, agxSlope, 1.2f, "AgX slope adjustment for highlight rolloff. Range [0.5, 2.0].");
+    RTX_OPTION("rtx.localtonemap", float, agxPower, 1.0f, "AgX power adjustment for midtone response. Range [0.5, 2.0].");
     RTX_OPTION("rtx.localtonemap", float, exposure, 0.75, "Exposure factor applied on average exposure.");
     RTX_OPTION("rtx.localtonemap", float, shadows, 2.0, "Shadow area strength. Higher values cause brighter shadows.");
     RTX_OPTION("rtx.localtonemap", float, highlights, 4.0, "Highlight area strength. Higher values cause darker highlight.");

--- a/src/dxvk/rtx_render/rtx_tone_mapping.cpp
+++ b/src/dxvk/rtx_render/rtx_tone_mapping.cpp
@@ -109,7 +109,42 @@ namespace dxvk {
     ImGui::Checkbox("Tonemapping Enabled", &tonemappingEnabledObject());
     if (tonemappingEnabled()) {
       ImGui::Indent();
-      ImGui::Checkbox("Finalize With ACES", &finalizeWithACESObject());
+      
+      // Tone mapping operator selection
+      const char* operators[] = { "Standard", "ACES", "AgX" };
+      int currentOp = useAgX() ? 2 : (finalizeWithACES() ? 1 : 0);
+      if (ImGui::Combo("Tone Mapping Operator", &currentOp, operators, IM_ARRAYSIZE(operators))) {
+        finalizeWithACES.setDeferred(currentOp == 1);
+        useAgX.setDeferred(currentOp == 2);
+      }
+
+      // AgX-specific controls (only show when AgX is selected)
+      if (useAgX()) {
+        ImGui::Indent();
+        ImGui::Text("AgX Controls:");
+        ImGui::Separator();
+        
+        // Basic controls
+        ImGui::DragFloat("AgX Gamma", &agxGammaObject(), 0.01f, 0.5f, 3.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
+        ImGui::DragFloat("AgX Saturation", &agxSaturationObject(), 0.01f, 0.5f, 2.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
+        ImGui::DragFloat("AgX Exposure Offset", &agxExposureOffsetObject(), 0.01f, -2.0f, 2.0f, "%.3f EV", ImGuiSliderFlags_AlwaysClamp);
+        
+        ImGui::Separator();
+        
+        // Look selection
+        const char* looks[] = { "None", "Punchy", "Golden", "Greyscale" };
+        ImGui::Combo("AgX Look", &agxLookObject(), looks, IM_ARRAYSIZE(looks));
+        
+        ImGui::Separator();
+        
+        // Advanced controls
+        ImGui::Text("Advanced:");
+        ImGui::DragFloat("AgX Contrast", &agxContrastObject(), 0.01f, 0.5f, 2.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
+        ImGui::DragFloat("AgX Slope", &agxSlopeObject(), 0.01f, 0.5f, 2.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
+        ImGui::DragFloat("AgX Power", &agxPowerObject(), 0.01f, 0.5f, 2.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
+        
+        ImGui::Unindent();
+      }
 
       ImGui::Combo("Dither Mode", &ditherModeObject(), "Disabled\0Spatial\0Spatial + Temporal\0");
 
@@ -254,7 +289,17 @@ namespace dxvk {
     pushArgs.colorGradingEnabled = colorGradingEnabled();
     pushArgs.enableAutoExposure = autoExposureEnabled;
     pushArgs.finalizeWithACES = finalizeWithACES();
+    pushArgs.useAgX = useAgX();
     pushArgs.useLegacyACES = RtxOptions::useLegacyACES();
+    
+    // AgX parameters
+    pushArgs.agxGamma = agxGamma();
+    pushArgs.agxSaturation = agxSaturation();
+    pushArgs.agxExposureOffset = agxExposureOffset();
+    pushArgs.agxLook = agxLook();
+    pushArgs.agxContrast = agxContrast();
+    pushArgs.agxSlope = agxSlope();
+    pushArgs.agxPower = agxPower();
 
     // Tonemap args
     pushArgs.performSRGBConversion = performSRGBConversion;

--- a/src/dxvk/rtx_render/rtx_tone_mapping.h
+++ b/src/dxvk/rtx_render/rtx_tone_mapping.h
@@ -108,6 +108,14 @@ namespace dxvk {
     RTX_OPTION("rtx.tonemap", float, toneCurveMaxStops, 8.0f, "High endpoint of the tone curve (in log2(linear))."); 
     RTX_OPTION("rtx.tonemap", bool,  tuningMode, false, "A flag to enable a debug visualization to tune the tonemapping exposure curve with, as well as exposing parameters for tuning the tonemapping in the UI.");
     RTX_OPTION("rtx.tonemap", bool,  finalizeWithACES, false, "A flag to enable applying a final pass of ACES tonemapping to the tonemapped result.");
+    RTX_OPTION("rtx.tonemap", bool,  useAgX, false, "A flag to enable AgX tonemapping instead of ACES or standard tonemapping.");
+    RTX_OPTION("rtx.tonemap", float, agxGamma, 2.0f, "AgX gamma adjustment for contrast control. Lower values increase contrast. Range [0.5, 3.0].");
+    RTX_OPTION("rtx.tonemap", float, agxSaturation, 1.1f, "AgX saturation multiplier. Higher values increase color saturation. Range [0.5, 2.0].");
+    RTX_OPTION("rtx.tonemap", float, agxExposureOffset, 0.0f, "AgX exposure offset in EV stops. Positive values brighten the image. Range [-2.0, 2.0].");
+    RTX_OPTION("rtx.tonemap", int, agxLook, 0, "AgX look selection: 0=None, 1=Punchy, 2=Golden, 3=Greyscale. Different aesthetic looks for AgX.");
+    RTX_OPTION("rtx.tonemap", float, agxContrast, 1.0f, "AgX contrast adjustment. Higher values increase contrast. Range [0.5, 2.0].");
+    RTX_OPTION("rtx.tonemap", float, agxSlope, 1.0f, "AgX slope adjustment for highlight rolloff. Range [0.5, 2.0].");
+    RTX_OPTION("rtx.tonemap", float, agxPower, 1.0f, "AgX power adjustment for midtone response. Range [0.5, 2.0].");
     RTX_OPTION("rtx.tonemap", float, dynamicRange, 15.f, "Range [0, inf). Without further adjustments, the tone curve will try to fit the entire luminance of the scene into the range [-dynamicRange, 0] in linear photographic stops. Higher values adjust for ambient monitor lighting; perfect conditions -> 17.587 stops.");
     RTX_OPTION("rtx.tonemap", float, shadowMinSlope, 0.f, "Range [0, inf). Forces the tone curve below a linear value of 0.18 to have at least this slope, making the tone darker.");
     RTX_OPTION("rtx.tonemap", float, shadowContrast, 0.f, "Range [0, inf). Additional gamma power to apply to the tone of the tone curve below shadowContrastEnd.");

--- a/src/dxvk/shaders/rtx/pass/local_tonemap/final_combine.comp.slang
+++ b/src/dxvk/shaders/rtx/pass/local_tonemap/final_combine.comp.slang
@@ -105,9 +105,10 @@ void main(uint2 threadId : SV_DispatchThreadID)
     mix(1.0, finalMultiplier, (luminance / lerpToUnityThreshold) * (luminance / lerpToUnityThreshold));
 
   vec3 texelFinal = originalColor.xyz * finalMultiplier;
-  if (cb.finalizeWithACES)
+  if (cb.finalizeWithACES || cb.useAgX)
   {
-    texelFinal = ACESFilm(texelFinal, cb.useLegacyACES);
+    texelFinal = applyToneMapping(texelFinal, cb.useAgX, cb.useLegacyACES, cb.agxGamma, cb.agxSaturation, cb.agxExposureOffset,
+                                  cb.agxLook, cb.agxContrast, cb.agxSlope, cb.agxPower);
   }
   if (cb.performSRGBConversion)
   {

--- a/src/dxvk/shaders/rtx/pass/local_tonemap/local_tonemapping.h
+++ b/src/dxvk/shaders/rtx/pass/local_tonemap/local_tonemapping.h
@@ -106,6 +106,16 @@ struct FinalCombineArgs
   uint ditherMode;
   uint frameIndex;
   uint useLegacyACES;
+  uint useAgX;
+  
+  float agxGamma;
+  float agxSaturation;
+  float agxExposureOffset;
+  uint agxLook;
+  
+  float agxContrast;
+  float agxSlope;
+  float agxPower;
   uint pad2;
 };
 

--- a/src/dxvk/shaders/rtx/pass/tonemap/AgX.hlsl
+++ b/src/dxvk/shaders/rtx/pass/tonemap/AgX.hlsl
@@ -1,0 +1,118 @@
+// AgX implementation based on https://github.com/MrLixm/AgXc
+
+// AgX Base Transform (Rec.2020 primaries to AgX working space)
+static const float3x3 AgX_InputTransform = 
+{
+    {0.842479062253094, 0.0784335999999992,  0.0792237451477643},
+    {0.0423282422610123, 0.878468636469772,  0.0791661274605434},
+    {0.0423756549057051, 0.0784336,          0.879142973793104}
+};
+
+// AgX Base Transform Output (AgX working space to Rec.2020 primaries)
+static const float3x3 AgX_OutputTransform =
+{
+    { 1.19687900512017, -0.0980208811401368, -0.0990297440797205},
+    {-0.0528968517574562, 1.15190312639708,   -0.0989611768448433},
+    {-0.0529716355144438, -0.0980434501171241, 1.15107367264116}
+};
+
+// AgX curve implementation
+float agx_default_contrast_approx(float x) {
+    float x2 = x * x;
+    float x4 = x2 * x2;
+    float x6 = x4 * x2;
+    
+    return + 15.5 * x6
+           - 40.14 * x4 * x
+           + 31.96 * x4
+           - 6.868 * x2 * x
+           + 0.4298 * x2
+           + 0.1191 * x
+           - 0.00232;
+}
+
+// AgX Look transforms
+float3 agx_look_punchy(float3 val) {
+    const float3x3 punchy = {
+        {1.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0}, 
+        {0.0, 0.0, 1.0}
+    };
+    
+    // Increase contrast and saturation
+    val = pow(val, 0.7);
+    val = lerp(dot(val, float3(0.2126, 0.7152, 0.0722)), val, 1.4);
+    return val;
+}
+
+float3 agx_look_golden(float3 val) {
+    // Golden hour look - warm highlights, cooler shadows
+    float luma = dot(val, float3(0.2126, 0.7152, 0.0722));
+    float3 warm = val * float3(1.1, 1.05, 0.9);
+    float3 cool = val * float3(0.9, 0.95, 1.1);
+    return lerp(cool, warm, smoothstep(0.2, 0.8, luma));
+}
+
+float3 agx_look_greyscale(float3 val) {
+    float luma = dot(val, float3(0.2126, 0.7152, 0.0722));
+    return float3(luma, luma, luma);
+}
+
+float3 apply_agx_look(float3 val, int look) {
+    switch(look) {
+        case 1: return agx_look_punchy(val);
+        case 2: return agx_look_golden(val);
+        case 3: return agx_look_greyscale(val);
+        default: return val;
+    }
+}
+
+float3 AgXToneMapping(float3 color, float gamma, float saturation, float exposureOffset, 
+                      int look, float contrast, float slope, float power) {
+    // Apply exposure offset
+    color = color * pow(2.0, exposureOffset);
+    
+    // Input transform to AgX working space
+    color = mul(AgX_InputTransform, color);
+    
+    // Ensure positive values for log transform
+    color = max(color, 1e-10);
+    
+    // Convert to log2 space
+    color = log2(color);
+    
+    // AgX constants
+    const float min_ev = -12.47393;
+    const float max_ev = 4.026069;
+    
+    // Normalize to [0, 1] range
+    color = (color - min_ev) / (max_ev - min_ev);
+    color = saturate(color);
+    
+    // Apply contrast and slope adjustments
+    color = pow(color, 1.0 / contrast);
+    color = color * slope;
+    
+    // Apply the AgX curve per channel
+    color.r = agx_default_contrast_approx(color.r);
+    color.g = agx_default_contrast_approx(color.g);
+    color.b = agx_default_contrast_approx(color.b);
+    
+    // Apply power adjustment for midtone response
+    color = pow(saturate(color), power);
+    
+    // Output transform back to display space
+    color = mul(AgX_OutputTransform, color);
+    
+    // Apply look
+    color = apply_agx_look(color, look);
+    
+    // Apply gamma correction
+    color = pow(saturate(color), 1.0 / gamma);
+    
+    // Apply saturation adjustment
+    float luma = dot(color, float3(0.2126, 0.7152, 0.0722));
+    color = lerp(float3(luma, luma, luma), color, saturation);
+    
+    return saturate(color);
+}

--- a/src/dxvk/shaders/rtx/pass/tonemap/tonemapping.h
+++ b/src/dxvk/shaders/rtx/pass/tonemap/tonemapping.h
@@ -121,6 +121,16 @@ struct ToneMappingApplyToneMappingArgs {
   uint ditherMode;
   uint frameIndex;
   uint useLegacyACES;
+  uint useAgX;
+  
+  float agxGamma;
+  float agxSaturation;
+  float agxExposureOffset;
+  uint agxLook;
+  
+  float agxContrast;
+  float agxSlope;
+  float agxPower;
   uint pad1;
 };
 

--- a/src/dxvk/shaders/rtx/pass/tonemap/tonemapping.slangh
+++ b/src/dxvk/shaders/rtx/pass/tonemap/tonemapping.slangh
@@ -25,6 +25,7 @@
 #include "rtx/utility/color.slangh"
 
 #include "ACES.hlsl"
+#include "AgX.hlsl"
 
 static const uint kHistogramFixedPointScale = 0x100;
 
@@ -68,4 +69,16 @@ float3 ACESFilm(float3 color, bool useLegacyACES, bool suppressBlackLevelClamp =
     return ACESFilmApproximation(color);
   }
   return ACESFitted(color, suppressBlackLevelClamp);
+}
+
+// Unified tone mapping function that handles ACES, AgX, or no tonemapping
+float3 applyToneMapping(float3 color, bool useAgX, bool useLegacyACES, float agxGamma = 0.8, float agxSaturation = 1.0, 
+                        float agxExposureOffset = 0.0, uint agxLook = 0, float agxContrast = 0.8, float agxSlope = 1.2, 
+                        float agxPower = 1.0, bool suppressBlackLevelClamp = false)
+{
+  if (useAgX)
+  {
+    return AgXToneMapping(color, agxGamma, agxSaturation, agxExposureOffset, agxLook, agxContrast, agxSlope, agxPower);
+  }
+  return ACESFilm(color, useLegacyACES, suppressBlackLevelClamp);
 }

--- a/src/dxvk/shaders/rtx/pass/tonemap/tonemapping_apply_tonemapping.comp.slang
+++ b/src/dxvk/shaders/rtx/pass/tonemap/tonemapping_apply_tonemapping.comp.slang
@@ -131,9 +131,10 @@ float3 applyToneMapping(float3 color, uint2 pixelPosition)
       // Normal tone mapping
       color = dynamicToneMapper(color);
       
-      if (cb.finalizeWithACES)
+      if (cb.finalizeWithACES || cb.useAgX)
       {
-        color = ACESFilm(color, cb.useLegacyACES);
+        color = applyToneMapping(color, cb.useAgX, cb.useLegacyACES, cb.agxGamma, cb.agxSaturation, cb.agxExposureOffset, 
+                                 cb.agxLook, cb.agxContrast, cb.agxSlope, cb.agxPower);
       }
     } 
     else


### PR DESCRIPTION
Another tonemapper for users to use. Offers some extra controls to suit the visual appearance of a game

Implementation is based on [AgXc](https://github.com/MrLixm/AgXc)
The defaults are a best-attempt visual match to the ACES tonemapper

Adjustable options:
![image](https://github.com/user-attachments/assets/3e695348-e988-4a5c-8d71-08e3e3ed1b71)
