### PR TITLE
ImGui Theme - UI Scaling Options - Layout Fixes

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui.h
+++ b/src/dxvk/imgui/dxvk_imgui.h
@@ -140,6 +140,8 @@ namespace dxvk {
     Rc<ImGuiSplash>       m_splash;
     Rc<ImGuiCapture>      m_capture;
     // Note: May be NULL until the font loads, needs to be checked before use.
+    ImFont*               m_regularFont = nullptr;
+    // Note: May be NULL until the font loads, needs to be checked before use.
     ImFont*               m_largeFont = nullptr;
 
     ImGuiContext*         m_context;
@@ -151,7 +153,7 @@ namespace dxvk {
     bool                  m_windowOnRight = true;
     float                 m_windowWidth = 492.f;
     float                 m_userWindowWidth = 600.f;
-    float                 m_userWindowHeight = 550.f;
+    float                 m_userWindowHeight = 720.f;
     const char*           m_userGraphicsWindowTitle = "User Graphics Settings";
     bool                  m_userGraphicsSettingChanged = false;
     bool m_hudMessageTimeReset = false;
@@ -225,7 +227,9 @@ namespace dxvk {
     void createFontsTexture(const Rc<DxvkContext>& ctx);
 
     void setupStyleBackgroundColor(const float& alpha);
-    void setupStyle(ImGuiStyle* dst = NULL);      // custom style
+
+    // Custom style
+    void setupStyle(ImGuiStyle* dst = NULL);
     void showVsyncOptions(bool enableDLFGGuard);
 
     void processHotkeys();

--- a/src/dxvk/imgui/dxvk_imgui.h
+++ b/src/dxvk/imgui/dxvk_imgui.h
@@ -149,7 +149,7 @@ namespace dxvk {
     bool                  m_init = false;
 
     bool                  m_windowOnRight = true;
-    float                 m_windowWidth = 450.f;
+    float                 m_windowWidth = 492.f;
     float                 m_userWindowWidth = 600.f;
     float                 m_userWindowHeight = 550.f;
     const char*           m_userGraphicsWindowTitle = "User Graphics Settings";
@@ -224,6 +224,7 @@ namespace dxvk {
 
     void createFontsTexture(const Rc<DxvkContext>& ctx);
 
+    void setupStyleBackgroundColor(const float& alpha);
     void setupStyle(ImGuiStyle* dst = NULL);      // custom style
     void showVsyncOptions(bool enableDLFGGuard);
 
@@ -237,7 +238,9 @@ namespace dxvk {
     RTX_OPTION("rtx.gui", std::uint32_t, hudMessageAnimatedDotDurationMilliseconds, 1000, "A duration in milliseconds between each dot in the animated dot sequence for HUD messages. Must be greater than 0.\nThese dots help indicate progress is happening to the user with a bit of animation which can be configured to animate at whatever speed is desired.");
     RTX_OPTION("rtx.gui", float, reflexStatRangeInterpolationRate, 0.05f, "A value controlling the interpolation rate applied to the Reflex stat graph ranges for smoother visualization.");
     RTX_OPTION("rtx.gui", float, reflexStatRangePaddingRatio, 0.05f, "A value specifying the amount of padding applied to the Reflex stat graph ranges as a ratio to the calculated range.");
-  
+    RTX_OPTION("rtx.gui", bool, compactGui, false, "A setting to toggle between compact and spacious GUI modes.");
+    RTX_OPTION("rtx.gui", float, backgroundAlpha, 0.90f, "A value controlling the alpha of the GUI background.");
+
     void onCloseMenus();
     void onOpenMenus();
     void freeUnusedMemory();

--- a/src/dxvk/rtx_render/rtx_global_volumetrics.cpp
+++ b/src/dxvk/rtx_render/rtx_global_volumetrics.cpp
@@ -249,16 +249,13 @@ namespace dxvk {
     };
     static_assert(sizeof(volumericQualityLevelName) / sizeof(volumericQualityLevelName[0]) == QualityLevel::QualityCount);
 
-    ImGui::Text("Set Quality Level Preset:");
     for (uint32_t i = 0; i < QualityLevel::QualityCount; i++) {
       if (ImGui::Button(volumericQualityLevelName[i])) {
         setQualityLevel((QualityLevel) i);
       }
-
-      if (i < QualityLevel::QualityCount - 1) {
-        ImGui::SameLine();
-      }
+      ImGui::SameLine();
     }
+    ImGui::TextUnformatted("Quality Level Preset");
   }
 
   void RtxGlobalVolumetrics::showImguiUserSettings() {
@@ -340,16 +337,17 @@ namespace dxvk {
         };
         static_assert((sizeof(volumericPresetName) / sizeof(volumericPresetName[0]) - 1) == PresetType::PresetCount);
 
-        ImGui::Text("Set Quality Level Preset:");
+        ImGui::Text("Volumetric Visual Presets:");
 
-        const int indent = 200;
+        const float indent = 60.0f;
         static int itemIndex = 0;
-        ImGui::PushItemWidth(ImGui::GetWindowWidth() - indent);
+        ImGui::PushItemWidth(ImGui::GetContentRegionMax().x - indent);
         ImGui::PushID("volumetric visual preset");
         ImGui::ListBox("", &itemIndex, &volumericPresetName[0], (int) PresetType::PresetCount + 1, 3);
         ImGui::PopID();
         ImGui::PopItemWidth();
-        if (ImGui::Button("Apply") && itemIndex > 0) {
+
+        if (ImGui::Button("Apply", ImVec2(ImGui::GetContentRegionMax().x - indent, 0)) && itemIndex > 0) {
           setPreset((PresetType) (itemIndex - 1));
           itemIndex = 0;
         }
@@ -429,7 +427,9 @@ namespace dxvk {
       ImGui::Separator();
       ImGui::Dummy({ 0, 4 });
       {
+        ImGui::Indent();
         m_device->getCommon()->metaComposite().showDepthBasedFogImguiSettings();
+        ImGui::Unindent();
       }
 
       ImGui::Unindent();

--- a/src/dxvk/rtx_render/rtx_imgui.cpp
+++ b/src/dxvk/rtx_render/rtx_imgui.cpp
@@ -3,9 +3,16 @@
 namespace ImGui {
 
   void ImGui::SetTooltipUnformatted(const char* text) {
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.26f, 0.31f, 0.31f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_PopupBg, ImVec4(0.99f, 0.96f, 0.78f, 0.920f));
     ImGui::BeginTooltipEx(ImGuiTooltipFlags_OverridePreviousTooltip, ImGuiWindowFlags_None);
     ImGui::TextUnformatted(text);
     ImGui::EndTooltip();
+    ImGui::PopStyleColor(2);
+  }
+
+  bool IsItemHoveredDelay(float delay_in_seconds) {
+    return ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && GImGui->HoveredIdTimer > delay_in_seconds;
   }
 
   void SetTooltipToLastWidgetOnHover(const char* text) {
@@ -14,7 +21,7 @@ namespace ImGui {
       return;
     }
 
-    if (!ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    if (!IsItemHoveredDelay(0.5f)) {
       return;
     }
 

--- a/src/dxvk/rtx_render/rtx_imgui.cpp
+++ b/src/dxvk/rtx_render/rtx_imgui.cpp
@@ -28,6 +28,22 @@ namespace ImGui {
     ImGui::SetTooltipUnformatted(text);
   }
 
+  void TextCentered(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x - ImGui::CalcTextSize(fmt).x) * 0.5f);
+    ImGui::TextV(fmt, args);
+    va_end(args);
+  }
+
+  void TextWrappedCentered(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x - ImGui::CalcTextSize(fmt).x) * 0.5f);
+    ImGui::TextWrappedV(fmt, args);
+    va_end(args);
+  }
+
   bool Checkbox(const char* label, dxvk::RtxOption<bool>* rtxOption) {
     bool value = rtxOption->get();
     bool changed = IMGUI_ADD_TOOLTIP(Checkbox(label, &value), rtxOption->getDescription());

--- a/src/dxvk/rtx_render/rtx_imgui.h
+++ b/src/dxvk/rtx_render/rtx_imgui.h
@@ -42,6 +42,8 @@ namespace ImGui {
   // Adds a tooltip to the imguiCommand and returns boolean result from the passed in imguiCommand
 #define IMGUI_ADD_TOOLTIP(imguiCommand, tooltip) ImGui::addTooltipAndPassthroughValue((imguiCommand), tooltip)
 
+  IMGUI_API void TextCentered(const char* fmt, ...);
+  IMGUI_API void TextWrappedCentered(const char* fmt, ...);
   IMGUI_API bool Checkbox(const char* label, dxvk::RtxOption<bool>* rtxOption);
   IMGUI_API bool Combo(const char* label, int* current_item, const std::pair<const char*, const char*> items[], int items_count, int popup_max_height_in_items = -1);
   IMGUI_API bool Combo(const char* label, int* current_item, bool(*items_getter)(void* data, int idx, const char** out_text, const char** out_tooltip), void* data, int items_count, int popup_max_height_in_items = -1);

--- a/src/dxvk/rtx_render/rtx_imgui.h
+++ b/src/dxvk/rtx_render/rtx_imgui.h
@@ -10,7 +10,8 @@
 
 namespace ImGui {
 
-  IMGUI_API void          SetTooltipUnformatted(const char* text);  // Same as SetTooltip, just without text formatting (so percentage signs do not interfere with tooltips when not desired).
+  IMGUI_API void SetTooltipUnformatted(const char* text);  // Same as SetTooltip, just without text formatting (so percentage signs do not interfere with tooltips when not desired).
+  IMGUI_API bool IsItemHoveredDelay(float delay_in_seconds); // Same as IsItemHovered, but only returns true after the item was hovered for x amount of time
   IMGUI_API void SetTooltipToLastWidgetOnHover(const char* text);  // Conditionally sets tooltip if IsItemHovered() is true
 
   template<typename T>


### PR DESCRIPTION
#### This PR tweaks the existing ImGui theme to make it look similar to the Remix Toolkit. It fixes some minor oversights, contains some layout tweaks and other small improvements. 

It also adds a new `UI Options` section to the developer tab where the user can adjust GUI related settings such as:
- switching between compact and spacious modes (spacious being the default one, compact uses the original / prior spacing settings)
- adjusting the background alpha of the GUI
- button to switch between `Large` and `Regular` GUI scaling (essential for 4k resolutions on TV's or similar)
- manual GUI scaling (0.5 to 1.5)

<br>

<div align="center" markdown="1"> 

#### UI Options within the Developer Tab

<img src="https://github.com/user-attachments/assets/ca6602e2-b693-48d5-9930-b8e41d00c512"/> 
<div align="center" markdown="1"> 

<br>

#### Spacious vs. Compact Mode
</div>
<p float="middle">
  <img src="https://github.com/user-attachments/assets/d5fea9f4-4f66-452f-a0dc-03139832af03" width="400" />
  <img src="https://github.com/user-attachments/assets/8b39814c-8e12-4ded-9aad-fe532950f381" width="400" /> 
</p>



#### User Popup Menu

<img src="https://github.com/user-attachments/assets/4e5662d8-c06d-465f-a7ba-abf4a4e58786"/> 

<br>
<br>

**_Video Preview:_**
https://drive.google.com/file/d/1YQrlOTPEvq73oBypoN8xV5ECt8YwM4_z/view

</div>

<br>

#### User Popup Menu:
I've noticed that the `Graphics` tab was clipping the bottom of the viewport, hiding the buttons at the bottom.
- each tab now has a scrollable child window containing all content
- height of the popup is maintained no matter how much content a tab has
- this allows for a bit more spacing between options because it looked a little cramped before
- same popup/menu height is maintained throughout all of the tabs and using scrollable child windows allows for more _future_ content without worrying about the host window size
- removes the unsaved changes text hint and instead colors the "Save Settings" button and dynamically adjusts the tooltip of the button

#### Minor Tweaks and Fixes:
- renames `Always Developer Menu` to `Default Menu`
- adjusts `Graphics Settings Menu` button width to be roughly 3/4 of the window width
- adds a 0.5s delay to tooltips
- adds proper close buttons to the titlebars of all menus (and got rid of the close button within the user popup menu)
- adjusts the footer in the developer menu (button scaling, centered hint text)

#### Volumetric Options: 
  - removes prefixed `Set Quality Level Preset` text and adds it behind the buttons (looks cleaner in the user popup menu)
  - fixes incorrect volumetric preset text and changes it to `Volumetric Visual Presets:`
  - increases width of volumetric preset list box and apply button
  
 _____
### Notes:
I've opted to not create serialized options for GUI scaling because the GUI might end up looking bad if using someone else's config. Background Alpha and Compact/Spacious Modes are serialized and saved. It contradicts my prior statement, but it would make them pointless if I didn't do that.

This could be fixed by creating a secondary config file, eg: `rtx_user.conf` that only contains personalized remix options that do not need to be shared for mods to function. This however is not part of this PR and would be up for discussion.
