### PR TITLE
Make fog density threshold configurable for volumetrics

### DIFF
--- a/src/dxvk/rtx_render/rtx_global_volumetrics.cpp
+++ b/src/dxvk/rtx_render/rtx_global_volumetrics.cpp
@@ -503,9 +503,8 @@ namespace dxvk {
     float transmittanceMeasurementDistance = transmittanceMeasurementDistanceMeters() * RtxOptions::getMeterToWorldUnitScale();
     Vector3 multiScatteringEstimate = Vector3();
 
-    // Todo: Make this configurable in the future as this threshold was created specifically for Portal RTX's underwater fixed function fog.
-    constexpr float waterFogDensityThrehold = 0.065f;
-    const bool canUsePhysicalFog = shouldConvertToPhysicalFog(fogState, waterFogDensityThrehold);
+    // Check if fog density is below the configurable threshold to determine if physical volumetrics should be used
+    const bool canUsePhysicalFog = shouldConvertToPhysicalFog(fogState, fogDensityThreshold());
 
     if (
       enableFogRemap() &&

--- a/src/dxvk/rtx_render/rtx_global_volumetrics.h
+++ b/src/dxvk/rtx_render/rtx_global_volumetrics.h
@@ -192,6 +192,10 @@ namespace dxvk {
                "A value representing the scale of the fixed function fog's color in the multiscattering approximation.\n"
                "This scaling factor is applied to the fixed function fog's color and becomes a multiscattering approximation in the volumetrics system.\n"
                "Sometimes useful but this multiscattering approximation is very basic (just a simple ambient term for now essentially) and may not look very good depending on various conditions.");
+    RTX_OPTION("rtx.volumetrics", float, fogDensityThreshold, 0.065f,
+               "The fog density threshold for determining when to use physical volumetrics vs fixed function fog.\n"
+               "Values below this threshold will use physical volumetrics, while values above will fall back to fixed function fog.\n"
+               "This was originally set to 0.065f for Portal RTX's underwater fog compatibility.");
 
     enum class RaytraceMode {
       RayQuery = 0,


### PR DESCRIPTION
Add RTX_OPTION for fogDensityThreshold with default 0.065f
Replace hardcoded waterFogDensityThrehold in global volumetrics
Keeps Portal RTX compatibility while allowing other games to adjust threshold 
Fixes issue where D3D fog end values <= 67 disabled volumetrics entirely