### PR TITLE
Add alwaysRecalculateTextureHashes option for games that dynamically update/override existing textures

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -658,9 +658,13 @@ namespace dxvk {
     if (m_type != D3DRTYPE_TEXTURE || (m_desc.Usage & D3DUSAGE_DEPTHSTENCIL))
       return;
 
+    const bool alwaysRecalculateHash = RtxOptions::alwaysRecalculateTextureHashes();
+
     if (m_image->getHash() != 0) {
-      // Already setup.
-      return;
+      if (!alwaysRecalculateHash) {
+        // Already setup.
+        return;
+      }
     }
 
     // Use subresource 0 for hashing
@@ -682,6 +686,14 @@ namespace dxvk {
     } else {
       imageHash = XXH3_64bits(buffer->mapPtr(0), buffer->info().size);
     }
+
+    if (alwaysRecalculateHash) {
+      // Release old texture if hash changed
+      if (m_image->getHash() != imageHash) {
+        ImGUI::ReleaseTexture(m_image->getHash());
+      }
+    }
+
     // save hash to dxvkImage
     m_image->setHash(imageHash);
 

--- a/src/dxvk/imgui/dxvk_imgui.cpp
+++ b/src/dxvk/imgui/dxvk_imgui.cpp
@@ -2595,7 +2595,8 @@ namespace dxvk {
 
     if (IMGUI_ADD_TOOLTIP(ImGui::BeginTabItem("Step 1: Categorize Textures", nullptr, tab_item_flags), "Select texture definitions for Remix")) {
       spacing();
-      ImGui::Checkbox("Preserve discarded textures", &RtxOptions::keepTexturesForTaggingObject());
+      ImGui::Checkbox("Preserve Discarded Textures", &RtxOptions::keepTexturesForTaggingObject());
+      ImGui::Checkbox("Always Recalculate Hashes", &RtxOptions::alwaysRecalculateTextureHashesObject());
       separator();
 
       // set thumbnail size

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -1106,6 +1106,11 @@ namespace dxvk {
                "Whether or not to use slower XXH64 hash on texture upload.\n"
                "New projects should not enable this option as this solely exists for compatibility with older hashing schemes.");
 
+    RTX_OPTION("rtx", bool, alwaysRecalculateTextureHashes, false,
+               "Use this option to recalculate the hash of a texture every time it is used, as streaming systems might override textures with other textures when they are no longer in use.\n"
+               "This might result in the wrong textures being used on meshes, as Remix normally does not recalculate texture hashes for performance reasons.\n"
+               "You may need to restart to see the full effect.");
+
     RTX_OPTION("rtx", bool, serializeChangedOptionOnly, true, "");
 
     RTX_OPTION("rtx", uint32_t, applicationId, 102100511, "Used to uniquely identify the application to DLSS. Generally should not be changed without good reason.");


### PR DESCRIPTION
This PR adds a new option called `Always Recalculate Hashes` under the Game Setup - Textures Tab.

<img width="497" height="316" alt="image" src="https://github.com/user-attachments/assets/a5c63296-32a8-40e0-95d5-e7e92ce11e87" />

<br>
<br>

This new option can help in games that dynamically update/override existing textures. Remix normally does not update the hash after texture creation which can lead to issues with texture replacements or texture tagging.

The most severe issue I had was a texture tagged as UI that was switched out with a texture used on a mesh after playing the game for a bit and remix kept the hash of the original UI texture. One can imagine the result.

That was very rare. Most of the time it resulted in this:

https://github.com/user-attachments/assets/8219d090-735f-4106-8708-e60b2b2dbe74

### GTA San Andreas - Hemry (Discord May 2025)

> I found some weird behavior, the albedo texture changes when viewing with the in-game camera, but when using the Remix Debug Camera, it doesn't happen. What's stranger is that the albedo texture changes that is without any texture replacement being applied, while the normal map still correctly uses the material replacement texture.

https://github.com/user-attachments/assets/31786548-89be-4c43-b3d3-2f88fb79b290

Hemry tested this fix on GTA SA and reported the hash issue (switching textures) being fixed. 

### NFS Underground 2 - Hemry 
He also tested the fix here:
> I did a quick test in NFSU2: previously, changing the car color didn’t affect the texture hash, it kept using the same one.
But with the hash fix build, switching cars now generates a different hash, and it even flushes unused textures automatically.

> Previously, we didn’t have stable hashes for car paint or vehicle meshes, the texture hash would change randomly. The only stable one was Rachael’s Z350 meshhash. But now, with this fix, it looks like some beginner cars can be replaced properly, as long as the player doesn’t manually change the color or decals.
Definitely a big improvement.


### Other games/projects:

> It both fixes issues with tagging textures within Remix and also has made material replacements possible! 
Project64: https://discord.com/channels/1028444667789967381/1236261405909581896/1426800263557025903
