### PR TITLE
Fix struct initialization for Slang compiler compatibility

### DIFF
--- a/src/dxvk/shaders/rtx/pass/integrate/integrate_direct.slangh
+++ b/src/dxvk/shaders/rtx/pass/integrate/integrate_direct.slangh
@@ -181,18 +181,18 @@ void integrate_direct_pass(ivec2 threadIndex)
 
   // Integrate the Direct portion of the Path
 
-  DirectPathTextures directPathTextures;
-
-  directPathTextures.SharedFlags = SharedFlags;
-  directPathTextures.SharedMediumMaterialIndex = SharedMediumMaterialIndex;
-  directPathTextures.PrimaryDirectDiffuseLobeRadianceHitDistance = PrimaryDirectDiffuseLobeRadianceHitDistance;
-  directPathTextures.PrimaryDirectSpecularLobeRadianceHitDistance = PrimaryDirectSpecularLobeRadianceHitDistance;
-  directPathTextures.SecondaryCombinedDiffuseLobeRadianceHitDistance = SecondaryCombinedDiffuseLobeRadianceHitDistance;
-  directPathTextures.SecondaryCombinedSpecularLobeRadianceHitDistance = SecondaryCombinedSpecularLobeRadianceHitDistance;
-  directPathTextures.IndirectRayOriginDirection = aliasedData0.IndirectRayOriginDirection;
-  directPathTextures.IndirectThroughputConeRadius = IndirectThroughputConeRadius;
-  directPathTextures.IndirectFirstHitPerceptualRoughness = aliasedData1.IndirectFirstHitPerceptualRoughness;
-  directPathTextures.PrimaryRtxdiIlluminance = PrimaryRtxdiIlluminance;
+  DirectPathTextures directPathTextures = {
+    SharedFlags,
+    SharedMediumMaterialIndex,
+    PrimaryDirectDiffuseLobeRadianceHitDistance,
+    PrimaryDirectSpecularLobeRadianceHitDistance,
+    SecondaryCombinedDiffuseLobeRadianceHitDistance,
+    SecondaryCombinedSpecularLobeRadianceHitDistance,
+    aliasedData0.IndirectRayOriginDirection,
+    IndirectThroughputConeRadius,
+    aliasedData1.IndirectFirstHitPerceptualRoughness,
+    PrimaryRtxdiIlluminance
+  };
 
   integrateDirectPath(
     rng, threadIndex, directPathTextures,

--- a/src/dxvk/shaders/rtx/pass/integrate/integrate_indirect.slangh
+++ b/src/dxvk/shaders/rtx/pass/integrate/integrate_indirect.slangh
@@ -143,10 +143,10 @@ void integrate_indirect_pass(ivec2 threadIndex)
 
   // Integrate the Indirect portion of the Path
 
-  IndirectPathTextures indirectPathTextures;
-
-  indirectPathTextures.PrimaryWorldPositionWorldTriangleNormal = PrimaryWorldPositionWorldTriangleNormal;
-  indirectPathTextures.IndirectRadianceHitDistance = IndirectRadianceHitDistance;// aliasedData0.IndirectRadianceHitDistance;
+  IndirectPathTextures indirectPathTextures = {
+    PrimaryWorldPositionWorldTriangleNormal,
+    IndirectRadianceHitDistance // aliasedData0.IndirectRadianceHitDistance
+  };
   
   integrateIndirectPath(
     gbufferPixelCoordinate, INTEGRATE_INDIRECT_SBT_OFFSET_STANDARD, indirectPathTextures,

--- a/src/dxvk/shaders/rtx/pass/integrate/integrate_indirect_closesthit.rchit.slang
+++ b/src/dxvk/shaders/rtx/pass/integrate/integrate_indirect_closesthit.rchit.slang
@@ -257,10 +257,10 @@ void main(inout PathState rayPayload : SV_RayPayload, in float2 barycentricCoord
 
   // Invoke the Integrate Path Vertex function and handle the payload
 
-  IndirectPathTextures indirectPathTextures;
-
-  indirectPathTextures.PrimaryWorldPositionWorldTriangleNormal = PrimaryWorldPositionWorldTriangleNormal;
-  indirectPathTextures.IndirectRadianceHitDistance = IndirectRadianceHitDistance;
+  IndirectPathTextures indirectPathTextures = {
+    PrimaryWorldPositionWorldTriangleNormal,
+    IndirectRadianceHitDistance
+  };
 
   integratePathVertex(indirectPathTextures, rayHitInfo, rayPayload);
 }

--- a/src/dxvk/shaders/rtx/pass/integrate/integrate_indirect_miss.rmiss.slang
+++ b/src/dxvk/shaders/rtx/pass/integrate/integrate_indirect_miss.rmiss.slang
@@ -92,10 +92,10 @@ void main(inout PathState rayPayload : SV_RayPayload)
 
   // Invoke the Integrate Path Vertex function and handle the payload
 
-  IndirectPathTextures indirectPathTextures;
-
-  indirectPathTextures.PrimaryWorldPositionWorldTriangleNormal = PrimaryWorldPositionWorldTriangleNormal;
-  indirectPathTextures.IndirectRadianceHitDistance = IndirectRadianceHitDistance;
+  IndirectPathTextures indirectPathTextures = {
+    PrimaryWorldPositionWorldTriangleNormal,
+    IndirectRadianceHitDistance
+  };
 
   integratePathVertex(indirectPathTextures, rayHitInfo, rayPayload);
 }


### PR DESCRIPTION
Update DirectPathTextures and IndirectPathTextures initialization to use aggregate initialization instead of default initialization.

Newer Slang compiler enforces stricter rules and requires explicit initialization for structs containing texture fields.

Changes:
- integrate_indirect.slangh
- integrate_direct.slangh
- integrate_indirect_closesthit.rchit.slang
- integrate_indirect_miss.rmiss.slang

Fixes compilation error 41024 with Slang v2025.23.1+