### PR TITLE
Add empty constructors to structs with resource fields

### DIFF
--- a/src/dxvk/shaders/rtx/algorithm/path_state.slangh
+++ b/src/dxvk/shaders/rtx/algorithm/path_state.slangh
@@ -514,6 +514,8 @@ struct PathState : IBasePayloadState
 
 struct DirectPathTextures
 {
+  __init() {} // Empty constructor is required by Slang to avoid the error 41024
+
   RWTexture2D<uint16_t> SharedFlags;
   RWTexture2D<uint16_t> SharedMediumMaterialIndex;
   RWTexture2D<float4> PrimaryDirectDiffuseLobeRadianceHitDistance;
@@ -528,6 +530,8 @@ struct DirectPathTextures
 
 struct IndirectPathTextures
 {
+  __init() {} // Empty constructor is required by Slang to avoid the error 41024
+
   Texture2D<float4> PrimaryWorldPositionWorldTriangleNormal;
   RWTexture2D<float4> IndirectRadianceHitDistance;
 };


### PR DESCRIPTION
# Description

## Problem
RTX Remix shaders fail to compile with recent versions of the Slang shader compiler (v2025.23.2+) due to error 41024:
```
error 41024: cannot default-initialize struct 'DirectPathTextures' with '{}' 
because it contains an uninitialized texture field
```

This error occurs when attempting to instantiate structs that contain resource types (e.g., `Texture2D`, `RWTexture2D`) without providing explicit initialization for those fields.

## Root Cause
Slang recently introduced stricter validation to prevent default-initialization of resource types using empty braces `{}`. This is because downstream compilers like DXC do not support default-initializing resources, making this pattern unsafe and non-portable.

The error triggers when code like this is encountered:
```slang
struct DirectPathTextures {
  RWTexture2D<uint16_t> SharedFlags;
  // ... more resource fields
};

// This line triggers error 41024 in Slang 2025.23+:
DirectPathTextures directPathTextures;
```

## Solution
Add empty constructors `__init() {}` to structs containing resource fields that are explicitly instantiated in shader code:

**File:** `src/dxvk/shaders/rtx/algorithm/path_state.slangh`

```slang
struct DirectPathTextures
{
  __init() {}  // Empty constructor prevents error 41024

  RWTexture2D<uint16_t> SharedFlags;
  RWTexture2D<uint16_t> SharedMediumMaterialIndex;
  // ... other fields
};

struct IndirectPathTextures
{
  __init() {}  // Empty constructor prevents error 41024

  Texture2D<float4> PrimaryWorldPositionWorldTriangleNormal;
  RWTexture2D<float4> IndirectRadianceHitDistance;
};
```

The empty constructor allows the struct to be instantiated without attempting to default-initialize the resource fields. The existing code pattern of field-by-field assignment continues to work correctly:

```slang
DirectPathTextures directPathTextures;  // OK with __init() {}
directPathTextures.SharedFlags = SharedFlags;
directPathTextures.SharedMediumMaterialIndex = SharedMediumMaterialIndex;
// ... assign other fields
```

## Why Only These Structs?

**Fixed (2 structs):**
- `DirectPathTextures` - explicitly instantiated in `integrate_direct.slangh`
- `IndirectPathTextures` - explicitly instantiated in `integrate_indirect.slangh`, `integrate_indirect_closesthit.rchit.slang`, and `integrate_indirect_miss.rmiss.slang`
- This is a **minimal, non-breaking change** required for compatibility with current and future Slang compiler versions. It does not affect shader functionality or performance.


**Not Fixed (6+ structs):**
- `AliasedData0`, `AliasedData1`, `AliasedData2` (in various `*_bindings.slangh` files)

These are declared as **`uniform struct`** bindings:
```slang
layout(binding = X)
uniform struct AliasedData0 {
  Texture2D<float4> SomeField;
  RWTexture2D<float4> AnotherField;
} aliasedData0;  // This is a shader input binding, NOT a construction
```

The `uniform struct` pattern declares a **shader input binding** (similar to a uniform buffer), not a struct instance. These are never instantiated or constructed in shader code - they're bound by the host application. Therefore, they don't trigger error 41024 and don't need the fix.

## Related
- Remix issue https://github.com/NVIDIAGameWorks/dxvk-remix/issues/118
- Slang issue https://github.com/shader-slang/slang/issues/8655
- Slang diagnostic: error 41024 (`cannotDefaultInitializeResource`)
  - Link to [slang-diagnostic-defs.h](https://github.com/shader-slang/slang/blob/e694c6c56aa665b77d2d7a034a3dd3a9854f31bc/source/slang/slang-diagnostic-defs.h#L2621)
- This fix enables the [RTX Remix nightly CI](https://github.com/shader-slang/slang/actions/workflows/compile-rtx-remix-shaders-nightly.yml) to pass with the latest Slang and Remix

