### PR TITLE
Make fog density threshold configurable

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui_about.cpp
+++ b/src/dxvk/imgui/dxvk_imgui_about.cpp
@@ -92,6 +92,7 @@ namespace dxvk {
     : m_sections({
       { "Github Contributors", // Sorted alphabetically by last name
         { "Lorenzo 'King Vulpes' Acevedo IV",
+          "Quinn 'Binq Adams' Baddams",
           "Samuel 'CR' Bowman'",
           "Alexis 'Sortifal' Bruneteau",
           "Ethan 'Xenthio' Cardwell",

--- a/src/dxvk/rtx_render/rtx_global_volumetrics.cpp
+++ b/src/dxvk/rtx_render/rtx_global_volumetrics.cpp
@@ -487,9 +487,9 @@ namespace dxvk {
     float transmittanceMeasurementDistance = transmittanceMeasurementDistanceMeters() * RtxOptions::getMeterToWorldUnitScale();
     Vector3 multiScatteringEstimate = Vector3();
 
-    // Todo: Make this configurable in the future as this threshold was created specifically for Portal RTX's underwater fixed function fog.
-    constexpr float waterFogDensityThrehold = 0.065f;
-    const bool canUsePhysicalFog = shouldConvertToPhysicalFog(fogState, waterFogDensityThrehold);
+    // Check if fog density is below the configurable threshold to determine if physical volumetrics should be used.
+    // This threshold was created specifically for Portal RTX's underwater fixed function fog.
+    const bool canUsePhysicalFog = shouldConvertToPhysicalFog(fogState, waterFogDensityThreshold());
 
     if (
       enableFogRemap() &&

--- a/src/dxvk/rtx_render/rtx_global_volumetrics.h
+++ b/src/dxvk/rtx_render/rtx_global_volumetrics.h
@@ -193,6 +193,10 @@ namespace dxvk {
                "A flag to enable or disable remapping fixed function fox's max distance. Only takes effect when fog remapping in general is enabled.\n"
                "Enables or disables remapping functionality relating to the max distance parameter of fixed function fog.\n"
                "This allows dynamic changes to the game's fog max distance to be reflected somewhat in the volumetrics system. Overrides the specified volumetric transmittance measurement distance.");
+    RTX_OPTION("rtx.volumetrics", float, waterFogDensityThreshold, 0.065f,
+               "The fog density threshold for determining when to use physical volumetrics vs fixed function fog.\n"
+               "Values below this threshold will use physical volumetrics, while values above will fall back to fixed function fog.\n"
+               "This threshold was created specifically for Portal RTX's underwater fixed function fog.");
     RTX_OPTION_ARGS("rtx.volumetrics", float, fogRemapMaxDistanceMinMeters, 1.0f,
                "A value controlling the \"max distance\" fixed function fog parameter's minimum remapping bound.\n"
                "Note that fog remapping and fog max distance remapping must be enabled for this setting to have any effect.  In meters.",


### PR DESCRIPTION
A simple change which enables the fog density threshold setting which was previously hardcoded, to be configured. The setting was used for Portal RTX originally.