### PR TITLE
Resolve C2360 for VS2026 by hoisting switch-local declarations

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -37,7 +37,7 @@ Write-Host "vswhere found at: $vsWhere" -ForegroundColor Yellow
 #
 # Get path to Visual Studio installation using vswhere.
 #
-$vsPath = &$vsWhere -latest -version "[16.0,18.0)" -products * `
+$vsPath = &$vsWhere -latest -version "[16.0,19.0)" -products * `
  -requires Microsoft.Component.MSBuild `
  -property installationPath
 If ([string]::IsNullOrEmpty("$vsPath")) {

--- a/src/dxvk/rtx_render/rtx_pathtracer_gbuffer.cpp
+++ b/src/dxvk/rtx_render/rtx_pathtracer_gbuffer.cpp
@@ -389,9 +389,9 @@ namespace dxvk {
     ctx->pushConstants(0, sizeof(pushArgs), &pushArgs);
 
 
+    const VkExtent3D workgroups = util::computeBlockCount(rayDims, VkExtent3D { 16, 8, 1 });
     switch (RtxOptions::renderPassGBufferRaytraceMode()) {
     case RaytraceMode::RayQuery:
-      VkExtent3D workgroups = util::computeBlockCount(rayDims, VkExtent3D { 16, 8, 1 });
       {
         ScopedGpuProfileZone(ctx, "Primary Rays");
         ctx->bindShader(VK_SHADER_STAGE_COMPUTE_BIT, getComputeShader(false, nrcEnabled, wboitEnabled));

--- a/src/dxvk/rtx_render/rtx_pathtracer_integrate_direct.cpp
+++ b/src/dxvk/rtx_render/rtx_pathtracer_integrate_direct.cpp
@@ -201,9 +201,9 @@ namespace dxvk {
 
     const bool ommEnabled = RtxOptions::getEnableOpacityMicromap();
 
+    const VkExtent3D workgroups = util::computeBlockCount(rayDims, VkExtent3D { 16, 8, 1 });
     switch (RtxOptions::renderPassIntegrateDirectRaytraceMode()) {
     case RaytraceMode::RayQuery:
-      VkExtent3D workgroups = util::computeBlockCount(rayDims, VkExtent3D { 16, 8, 1 });
       ctx->bindShader(VK_SHADER_STAGE_COMPUTE_BIT, getComputeShader());
       ctx->dispatch(workgroups.width, workgroups.height, workgroups.depth);
       break;

--- a/src/dxvk/rtx_render/rtx_pathtracer_integrate_indirect.cpp
+++ b/src/dxvk/rtx_render/rtx_pathtracer_integrate_indirect.cpp
@@ -500,9 +500,9 @@ namespace dxvk {
     {
       ScopedGpuProfileZone(ctx, "Integrate Indirect Raytracing");
       const NeeCachePass& neeCache = ctx->getCommonObjects()->metaNeeCache();
+      const VkExtent3D workgroups = util::computeBlockCount(rayDims, VkExtent3D { 16, 8, 1 });
       switch (RtxOptions::renderPassIntegrateIndirectRaytraceMode()) {
       case RaytraceMode::RayQuery:
-        VkExtent3D workgroups = util::computeBlockCount(rayDims, VkExtent3D { 16, 8, 1 });
         ctx->bindShader(VK_SHADER_STAGE_COMPUTE_BIT, getComputeShader(neeCacheEnabled, nrcEnabled, wboitEnabled));
         ctx->dispatch(workgroups.width, workgroups.height, workgroups.depth);
         break;


### PR DESCRIPTION
## Summary

Allow DXVK Remix to build cleanly under MSVC 19.x (Visual Studio 2026) with `/WX` enabled.

## Motivation

Three pathtracer dispatch sites declare `VkExtent3D workgroups` directly under a `case:` label inside a switch. MSVC 19.x emits C2360 / C2361 ("initialization of `workgroups` is skipped by `case` label") and, with `/WX`, the build aborts. The C++ rule is that a non-trivial initialization cannot be jumped over by other case labels in the same switch.

`build_common.ps1` separately rejects VS 2026 because its `vswhere` query is pinned to `[16.0,18.0)`.

## What Changed

- Hoist `const VkExtent3D workgroups = util::computeBlockCount(rayDims, VkExtent3D { 16, 8, 1 });` above the `switch` in three files:
  - `src/dxvk/rtx_render/rtx_pathtracer_gbuffer.cpp`
  - `src/dxvk/rtx_render/rtx_pathtracer_integrate_direct.cpp`
  - `src/dxvk/rtx_render/rtx_pathtracer_integrate_indirect.cpp`

  Only the `RayQuery` case uses `workgroups` (other modes call `traceRays`); the value is the same expression in all three files. Hoisting kills C2360 / C2361 without adding brace-wrapping inside each case body. The marginal cost of computing `workgroups` in non-`RayQuery` modes is an integer divide.

- Bump `build_common.ps1` `vswhere` version range from `[16.0,18.0)` to `[16.0,19.0)` so VS 2026 satisfies the lower-bound check while still rejecting older releases.

Net diff: 4 files, +4 / -4.

## Testing

Built `_Comp64DebugOptimized` end-to-end against VS 2026 + Vulkan SDK 1.4.x, ninja backend; produced `d3d9.dll` and ran install steps cleanly with no warnings or errors from any of the three modified pathtracer compilation units.