### PR TITLE
Add FLOAT16_2 (R16G16_SFLOAT) texcoord support

### DIFF
--- a/src/dxvk/imgui/dxvk_imgui_about.cpp
+++ b/src/dxvk/imgui/dxvk_imgui_about.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+* Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a
 * copy of this software and associated documentation files (the "Software"),
@@ -96,6 +96,7 @@ namespace dxvk {
           "Ethan 'Xenthio' Cardwell",
           "Alexander 'xoxor4d' Engel",
           "James Horsley 'mmdanggg2'",
+          "Kim 'Kim2091'",
           "Leonardo Leotte",
           "Jeffrey 'skurtyyskirts' Munoz",
           "Nico Rodrigues-McKenna",

--- a/src/dxvk/rtx_render/rtx_geometry_utils.cpp
+++ b/src/dxvk/rtx_render/rtx_geometry_utils.cpp
@@ -970,7 +970,15 @@ namespace dxvk {
     const void* pVertexData = input.positionBuffer.mapPtr((size_t)input.positionBuffer.offsetFromSlice());
     const uint32_t vertexCount = input.vertexCount;
     const size_t vertexStride = input.positionBuffer.stride();
-    
+
+    // R16G16_SFLOAT and other non-float32 texcoord formats cannot be safely read as Vector2 on the CPU.
+    // The interleaver converts them to R32G32_SFLOAT on the GPU, but this function operates on raw
+    // pre-interleave input geometry, so skip computation for unsupported formats.
+    const VkFormat texFmt = input.texcoordBuffer.vertexFormat();
+    if (texFmt != VK_FORMAT_R32G32_SFLOAT && texFmt != VK_FORMAT_R32G32B32_SFLOAT && texFmt != VK_FORMAT_R32G32B32A32_SFLOAT) {
+      return NAN;
+    }
+
     const void* pTexcoordData = input.texcoordBuffer.mapPtr((size_t)input.texcoordBuffer.offsetFromSlice());
     const size_t texcoordStride = input.texcoordBuffer.stride();
 

--- a/src/dxvk/rtx_render/rtx_geometry_utils.h
+++ b/src/dxvk/rtx_render/rtx_geometry_utils.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+* Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a
 * copy of this software and associated documentation files (the "Software"),
@@ -65,7 +65,7 @@ namespace dxvk {
      * \brief Currently we only support these texcoord formats...
      */
     static bool isTexcoordFormatValid(VkFormat format) {
-      return format == VK_FORMAT_R32G32B32A32_SFLOAT || format == VK_FORMAT_R32G32B32_SFLOAT || format == VK_FORMAT_R32G32_SFLOAT;
+      return format == VK_FORMAT_R32G32B32A32_SFLOAT || format == VK_FORMAT_R32G32B32_SFLOAT || format == VK_FORMAT_R32G32_SFLOAT || format == VK_FORMAT_R16G16_SFLOAT;
     }
 
     /**

--- a/src/dxvk/rtx_render/rtx_types.h
+++ b/src/dxvk/rtx_render/rtx_types.h
@@ -406,13 +406,18 @@ struct GeometryBufferData {
       positionData = nullptr;
     }
 
+    texcoordStride = 0;
+    texcoordData = nullptr;
+    // Only float32 texcoord formats can be safely read as Vector2 on the CPU.
+    // R16G16_SFLOAT and other non-float32 formats are converted to R32G32_SFLOAT by the GPU interleaver;
+    // treat them as absent here to avoid mis-reading packed half-float data as float2.
     if (geometryData.texcoordBuffer.defined()) {
-      constexpr size_t texcoordSubElementSize = sizeof(float);
-      texcoordStride = geometryData.texcoordBuffer.stride() / texcoordSubElementSize;
-      texcoordData = (float*) geometryData.texcoordBuffer.mapPtr((size_t) geometryData.texcoordBuffer.offsetFromSlice());
-    } else {
-      texcoordStride = 0;
-      texcoordData = nullptr;
+      const VkFormat texFmt = geometryData.texcoordBuffer.vertexFormat();
+      if (texFmt == VK_FORMAT_R32G32_SFLOAT || texFmt == VK_FORMAT_R32G32B32_SFLOAT || texFmt == VK_FORMAT_R32G32B32A32_SFLOAT) {
+        constexpr size_t texcoordSubElementSize = sizeof(float);
+        texcoordStride = geometryData.texcoordBuffer.stride() / texcoordSubElementSize;
+        texcoordData = (float*) geometryData.texcoordBuffer.mapPtr((size_t) geometryData.texcoordBuffer.offsetFromSlice());
+      }
     }
 
     if (geometryData.normalBuffer.defined()) {

--- a/src/dxvk/shaders/rtx/pass/interleave_geometry.h
+++ b/src/dxvk/shaders/rtx/pass/interleave_geometry.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
+* Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a
 * copy of this software and associated documentation files (the "Software"),
@@ -29,6 +29,10 @@
 #define asuint(x) *reinterpret_cast<const uint32_t*>(&x)
 #define WriteBuffer(T) T*
 #define ReadBuffer(T) const T*
+
+// CPU-side half-float to float conversion (GPU uses the f16tof32 intrinsic built-in)
+#include "../utility/f16_conversion.h"
+
 #else
 #define WriteBuffer(T) RWStructuredBuffer<T>
 #define ReadBuffer(T) StructuredBuffer<T>
@@ -42,6 +46,7 @@ namespace interleaver {
 
     // Passthrough format mapping
     VK_FORMAT_B8G8R8A8_UNORM = 44,
+    VK_FORMAT_R16G16_SFLOAT = 83,
     VK_FORMAT_R32G32_SFLOAT = 103,
     VK_FORMAT_R32G32B32_SFLOAT = 106,
     VK_FORMAT_R32G32B32A32_SFLOAT = 109,
@@ -49,6 +54,7 @@ namespace interleaver {
 
   bool formatConversionFloatSupported(uint32_t format) {
     switch (format) {
+    case SupportedVkFormats::VK_FORMAT_R16G16_SFLOAT:
     case SupportedVkFormats::VK_FORMAT_R32G32_SFLOAT:
     case SupportedVkFormats::VK_FORMAT_R32G32B32_SFLOAT:
     case SupportedVkFormats::VK_FORMAT_R32G32B32A32_SFLOAT:
@@ -71,6 +77,14 @@ namespace interleaver {
 
   float3 convert(uint32_t format, ReadBuffer(float) input, uint32_t index) {
     switch (format) {
+    case SupportedVkFormats::VK_FORMAT_R16G16_SFLOAT:
+    {
+      // Two half-floats packed into one 32-bit word: [G(31:16) | R(15:0)] in memory
+      uint data = asuint(input[index]);
+      float r = f16tof32(data & 0xFFFFu);
+      float g = f16tof32((data >> 16u) & 0xFFFFu);
+      return float3(r, g, 0);
+    }
     case SupportedVkFormats::VK_FORMAT_R32G32_SFLOAT:
       return float3(input[index + 0], input[index + 1], 0);
     case SupportedVkFormats::VK_FORMAT_R32G32B32_SFLOAT:

--- a/src/dxvk/shaders/rtx/utility/f16_conversion.h
+++ b/src/dxvk/shaders/rtx/utility/f16_conversion.h
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+* DEALINGS IN THE SOFTWARE.
+*/
+#pragma once
+
+// CPU-side half-float (IEEE 754 binary16) to float conversion.
+// On the GPU, f16tof32 is a built-in intrinsic; this header provides
+// the equivalent for C++ host code.
+
+#ifdef __cplusplus
+#include <cstdint>
+#include <cstring>
+
+inline float f16tof32(uint32_t h16) {
+  const uint32_t sign     = (h16 & 0x8000u) << 16u;
+  const uint32_t exponent = (h16 >> 10u) & 0x1fu;
+  const uint32_t mantissa =  h16 & 0x3ffu;
+  uint32_t result;
+  if (exponent == 0u) {
+    if (mantissa == 0u) {
+      result = sign; // +-zero
+    } else {
+      // Denormalized half -> normalized float
+      uint32_t shiftedMantissa = mantissa;
+      uint32_t shiftCount = 0u;
+      while (!(shiftedMantissa & 0x400u)) {
+        shiftedMantissa <<= 1u;
+        ++shiftCount;
+      }
+      shiftedMantissa &= 0x3ffu;
+      result = sign | ((113u - shiftCount) << 23u) | (shiftedMantissa << 13u);
+    }
+  } else if (exponent == 31u) {
+    result = sign | 0x7f800000u | (mantissa << 13u); // +-Inf or NaN
+  } else {
+    result = sign | ((exponent + 112u) << 23u) | (mantissa << 13u);
+  }
+  float f;
+  std::memcpy(&f, &result, sizeof(f));
+  return f;
+}
+
+#endif // __cplusplus

--- a/tests/rtx/unit/meson.build
+++ b/tests/rtx/unit/meson.build
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -84,6 +84,10 @@ tests += exe
 exe = executable('test_option_layer_export',  files('test_option_layer_export.cpp'), 
   include_directories : test_include_path, dependencies : [ d3d9_dep, test_unit_deps ], link_with: [ d3d9_dll, dxvk_lib ] , win_subsystem : 'console', override_options: ['cpp_std='+dxvk_cpp_std])
 test('test_option_layer_export', exe, env: test_env)
+tests += exe
+
+exe = executable('test_f16tof32',  files('test_f16tof32.cpp'),  include_directories : test_include_path, dependencies : test_unit_deps, win_subsystem : 'console', override_options: ['cpp_std='+dxvk_cpp_std])
+test('test_f16tof32', exe, env: test_env)
 tests += exe
 
 alias_target('unit_tests', tests)

--- a/tests/rtx/unit/test_f16tof32.cpp
+++ b/tests/rtx/unit/test_f16tof32.cpp
@@ -1,0 +1,158 @@
+/*
+* Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+* DEALINGS IN THE SOFTWARE.
+*/
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+
+// Test the actual CPU-side f16tof32 implementation
+#include "rtx/utility/f16_conversion.h"
+
+namespace {
+
+// Helper: build a half-float bit pattern from components
+uint32_t makeHalf(uint32_t sign, uint32_t exponent, uint32_t mantissa) {
+  return (sign << 15u) | (exponent << 10u) | mantissa;
+}
+
+// Helper: compare floats with tolerance
+void expectNear(float actual, float expected, float tolerance, const char* label) {
+  if (std::abs(actual - expected) > tolerance) {
+    std::cerr << label << ": expected " << expected << ", got " << actual << std::endl;
+    throw std::runtime_error(label);
+  }
+}
+
+void expectExact(float actual, float expected, const char* label) {
+  uint32_t a, b;
+  std::memcpy(&a, &actual, sizeof(actual));
+  std::memcpy(&b, &expected, sizeof(expected));
+  if (a != b) {
+    std::cerr << label << ": expected bits 0x" << std::hex << b
+              << ", got 0x" << a << std::dec << std::endl;
+    throw std::runtime_error(label);
+  }
+}
+
+class F16ToF32TestApp {
+public:
+  static void run() {
+    std::cout << std::endl << "Begin f16tof32 tests" << std::endl;
+    test_zeros();
+    test_normals();
+    test_denormals();
+    test_inf_nan();
+    test_roundtrip_known_values();
+    std::cout << "All f16tof32 tests passed" << std::endl;
+  }
+
+private:
+  static void test_zeros() {
+    std::cout << "  test_zeros" << std::endl;
+    // +0
+    expectExact(f16tof32(makeHalf(0, 0, 0)), 0.0f, "+zero");
+    // -0
+    expectExact(f16tof32(makeHalf(1, 0, 0)), -0.0f, "-zero");
+  }
+
+  static void test_normals() {
+    std::cout << "  test_normals" << std::endl;
+    // 1.0 = sign=0, exp=15, mant=0 -> 0x3C00
+    expectExact(f16tof32(0x3C00u), 1.0f, "1.0");
+    // -1.0 = 0xBC00
+    expectExact(f16tof32(0xBC00u), -1.0f, "-1.0");
+    // 0.5 = sign=0, exp=14, mant=0 -> 0x3800
+    expectExact(f16tof32(0x3800u), 0.5f, "0.5");
+    // 2.0 = sign=0, exp=16, mant=0 -> 0x4000
+    expectExact(f16tof32(0x4000u), 2.0f, "2.0");
+    // 65504.0 (max normal half) = sign=0, exp=30, mant=0x3FF -> 0x7BFF
+    expectExact(f16tof32(0x7BFFu), 65504.0f, "65504.0 (max normal)");
+    // -2.5 = sign=1, exp=16, mant=0x100 -> 0xC100
+    expectNear(f16tof32(0xC100u), -2.5f, 1e-6f, "-2.5");
+  }
+
+  static void test_denormals() {
+    std::cout << "  test_denormals" << std::endl;
+    // Smallest positive denorm: sign=0, exp=0, mant=1
+    // Expected: 2^-24 ~= 5.96046e-8
+    float smallest = f16tof32(makeHalf(0, 0, 1));
+    expectNear(smallest, 5.96046448e-8f, 1e-14f, "smallest denorm");
+    // Largest denorm: sign=0, exp=0, mant=0x3FF
+    // Expected: 0x3FF * 2^-24 = 1023 * 2^-24 ~= 6.09756e-5
+    float largest = f16tof32(makeHalf(0, 0, 0x3FF));
+    expectNear(largest, 6.09755516e-5f, 1e-10f, "largest denorm");
+  }
+
+  static void test_inf_nan() {
+    std::cout << "  test_inf_nan" << std::endl;
+    // +Inf: exp=31, mant=0 -> 0x7C00
+    float posInf = f16tof32(0x7C00u);
+    if (!std::isinf(posInf) || posInf < 0) {
+      throw std::runtime_error("+Inf failed");
+    }
+    // -Inf: 0xFC00
+    float negInf = f16tof32(0xFC00u);
+    if (!std::isinf(negInf) || negInf > 0) {
+      throw std::runtime_error("-Inf failed");
+    }
+    // NaN: exp=31, mant!=0 -> 0x7C01
+    float nan = f16tof32(0x7C01u);
+    if (!std::isnan(nan)) {
+      throw std::runtime_error("NaN failed");
+    }
+  }
+
+  static void test_roundtrip_known_values() {
+    std::cout << "  test_roundtrip_known_values" << std::endl;
+    // Test a set of known half-float bit patterns and their expected float values
+    struct TestCase {
+      uint32_t half;
+      float expected;
+    };
+    TestCase cases[] = {
+      { 0x3555u, 0.333251953125f }, // ~1/3
+      { 0x3C00u, 1.0f },
+      { 0x4200u, 3.0f },
+      { 0x4900u, 10.0f },
+      { 0x5640u, 100.0f },
+      { 0x6E10u, 6208.0f },
+    };
+    for (const auto& tc : cases) {
+      expectNear(f16tof32(tc.half), tc.expected, 1e-4f, "roundtrip known value");
+    }
+  }
+};
+
+} // anonymous namespace
+
+int main() {
+  try {
+    F16ToF32TestApp::run();
+  }
+  catch (const std::exception& e) {
+    std::cerr << e.what() << std::endl;
+    throw;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Some games (e.g. Mirror's Edge) store UV coordinates as half-precision floats using `D3DDECLTYPE_FLOAT16_2`, which maps to `VK_FORMAT_R16G16_SFLOAT`. The Remix geometry interleaver previously had no handler for this format, causing it to silently skip the texcoord buffer and fall back to vertex capture, resulting in broken texture lookups.

Add support for `VK_FORMAT_R16G16_SFLOAT` throughout the `texcoord` pipeline:

- interleave_geometry.h: 
  - add `R16G16_SFLOAT` to the `SupportedVkFormats` enum, mark it as a supported float conversion format, and add a `convert()` case that unpacks the two packed FP16 values from one 32-bit word into float2.
  - On the CPU side a portable f16tof32() helper is provided under `__cplusplus`; the GPU path uses the Slang built-in intrinsic.

- rtx_geometry_utils.h: 
   - extend `isTexcoordFormatValid()` to accept `VK_FORMAT_R16G16_SFLOAT` so the raw vertex buffer is used directly instead of discarding it and falling back to vertex shader capture.

Because `R16G16_SFLOAT` is not in `areFormatsGpuFriendly()`, geometry with this `texcoord` format always goes through the interleave path, where it is expanded to `R32G32_SFLOAT`. All downstream consumers (RT pipeline, game capturer) continue to see only `R32G32_SFLOAT` and require no changes.

I tested this in Metal Gear Rising: Revengeance and it appears to be working as expected.