### PR TITLE
Filter log level at emitMsg entry to avoid locale-facet UAF on shutdown

### DIFF
--- a/bridge/src/util/log/log.cpp
+++ b/bridge/src/util/log/log.cpp
@@ -163,6 +163,11 @@ namespace bridge_util {
   }
 
   void Logger::emitMsg(const LogLevel level, const std::string& message) {
+    // Filter early — formatMessage builds a std::stringstream whose locale-facet
+    // path can fault on a freed _Locimp; skip it for messages we'd drop anyway.
+    if (logger && level < logger->m_level) {
+      return;
+    }
     if(!logger) {
       auto ss = formatMessage(level, message);
       std::scoped_lock lock(s_mutex);


### PR DESCRIPTION
## Summary

Move the bridge logger's level check from `emitLine` to the top of `emitMsg`, so messages below the configured level never construct a `std::stringstream` and never touch the locale facet.

## Motivation

`bridge_util::Logger::formatMessage` builds a `std::stringstream` whose locale-facet path (`basic_iostream` ctor → `basic_ios::init` → `use_facet<ctype<char>>`) dereferences the global `_Locimp` via vtable. If `_Locimp` is freed during shutdown — for example, by the C++ runtime tearing down statics on DLL detach while another thread is still emitting log messages — the indirect virtual call faults with an instruction pointer that looks like freed-page bytes interpreted as a function pointer.

The pre-existing level filter ran inside `emitLine`, after `formatMessage` had already constructed the stream and touched the locale facet. By the time the filter could discard the message, the UAF window had already been entered.

## What Changed

`bridge/src/util/log/log.cpp`: add an early-exit at the top of `Logger::emitMsg` that compares `level` against `logger->m_level` before any stream construction. Pre-init (`logger == nullptr`) behavior is unchanged: messages still buffer to `s_preInitMsgs` unconditionally, matching prior semantics.

Net diff: `bridge/src/util/log/log.cpp` only, +5.

## Testing

The fix is a strict subset of the prior behavior: emitted (above-level) messages still take the same code path, and pre-init messages still buffer. The only change is that filtered-out messages now short-circuit before `formatMessage` runs. Verified the bridge logger still emits expected output at all configured levels through normal level-load and shutdown cycles. The locale-facet UAF signature (faulting IP looking like freed-page bytes inside the `basic_iostream`-construction path) no longer reproduces under shutdown stress.