### PR TITLE
Drop hot per-GetWindowLong debug log in window.cpp

### DIFF
--- a/bridge/src/client/window.cpp
+++ b/bridge/src/client/window.cpp
@@ -100,8 +100,7 @@ static LONG WINAPI NewGetWindowLong(_In_ HWND hWnd, _In_ int nIndex) {
     // If we haven't yet set the RemixWndProc, as is evident by g_gameWndProc being invalid, then just
     // call OrigGetWindowLong as usual
     if(isSet()) {
-      Logger::debug(format_string(kStr_newGetWindowLong_gettingWndProc, g_gameWndProc));
-      // We only handle cases wherein the window's handle matches the window's handle 
+      // We only handle cases wherein the window's handle matches the window's handle
       // used in D3DDEVICE_CREATION_PARAMETERS or D3DPRESENT_PARAMETERS
       if (hWnd == g_hwnd)
         return asLong(g_gameWndProc);

--- a/bridge/src/util/log/log_strings.h
+++ b/bridge/src/util/log/log_strings.h
@@ -38,7 +38,6 @@ namespace logger_strings {
   namespace WndProc {
     constexpr char* kStr_newSetWindowLong_settingHwnd = "[WndProc][NewSetWindowLong] Setting new HWND=0x%08x, OldHWND=0x%08x";
     constexpr char* kStr_newSetWindowLong_settingWndProc = "[WndProc][NewSetWindowLong] Setting NewWndProc=0x%08x, OldWndProc=0x%08x";
-    constexpr char* kStr_newGetWindowLong_gettingWndProc = "[WndProc][NewGetWindowLong] Getting WndProc=0x%08x";
     constexpr char* kStr_init_attachErr = "[WndProc][init] Attach failed!";
     constexpr char* kStr_terminate_detachErr = "[WndProc][terminate] Detach failed!";
     constexpr char* kStr_set_implicitWarn = "[WndProc][set] Calling WndProc::set(...) without an intermediate unset(). Calling implicitly...";


### PR DESCRIPTION
## Summary

Remove a debug log line that fires on every `NewGetWindowLong<>(GWLP_WNDPROC)` call, plus its now-orphaned format string.

## Motivation

`NewGetWindowLong<>(GWLP_WNDPROC)` is a hot path: any host process that periodically queries the window procedure (some game engines do this once per frame, or per input event) drives this log line at high frequency. The `Logger::debug` call constructs a `std::stringstream` via `formatMessage` on every call regardless of the configured log level — the level check happens later in `emitLine` — so the cost is paid even when the message would be discarded.

`SetWindowLong` logging is left in place: it fires only on actual `WndProc` updates and is genuinely useful for diagnosing wndproc ownership.

## What Changed

- `bridge/src/client/window.cpp`: remove the `Logger::debug(format_string(kStr_newGetWindowLong_gettingWndProc, …))` call inside `NewGetWindowLong`.
- `bridge/src/util/log/log_strings.h`: remove the now-unused `kStr_newGetWindowLong_gettingWndProc` format string.

Net diff: 2 files, +1 / -3.

## Testing

The removed log line was a pure side-effect (no return value, no state mutation). Bridge behavior is unchanged for any caller of `NewGetWindowLong<true|false>`; only the per-call debug emission is gone. Verified via normal level-load and HUD/menu interaction that no bridge functionality regressed.