### PR TITLE
Treat undefined config options as silent fallback in Config::getOption

### DIFF
--- a/bridge/src/util/config/config.h
+++ b/bridge/src/util/config/config.h
@@ -100,6 +100,11 @@ namespace bridge_util {
         return T();
       }
       const std::string& value = get().getOptionValue(option);
+      if (value.empty()) {
+        // Missing options use the caller-supplied fallback silently —
+        // a fallback parameter is the explicit contract for absence.
+        return fallback;
+      }
       T result;
       if (parseOptionValue(value, result)) {
         return result;


### PR DESCRIPTION
## Summary

Stop logging "Option failed to parse" when a bridge config option is simply not defined. Real parse failures (value present but malformed) still warn.

## Motivation

`Config::getOption<T>` (in `bridge/src/util/config/config.h`) previously logged `Logger::warn("Option failed to parse: <name>")` whenever the option wasn't defined in any config file — the empty looked-up value would fall through to `parseOptionValue`, which fails on empty input. Several options are read on hot paths (e.g. `client.optimizedDynamicLock` fires from the `LockableBuffer` ctor); a per-call warning floods the log at high frequency under heavy buffer creation.

An empty looked-up value semantically means the option is undefined, which is exactly what the `fallback` parameter is for — the explicit contract for absence.

## What Changed

`bridge/src/util/config/config.h`: in `Config::getOption<T>`, short-circuit to the supplied `fallback` when `getOptionValue(option)` returns an empty string. Real parse failures (non-empty value that fails `parseOptionValue`) still emit the `Logger::warn` as before.

Net diff: `bridge/src/util/config/config.h` only, +5.

## Testing

Verified that:
- Options not defined in any config now silently use their fallback (no log emission).
- Options defined with valid values continue to parse correctly.
- Options defined with malformed values still emit the parse-failure warning.

The behavioral change is limited to the absent-option case, which previously logged but otherwise returned the same fallback value.