### PR TITLE
BlasEntry::m_linkedInstances: std::vector → std::unordered_set for O(1) unlink

### DIFF
--- a/src/dxvk/rtx_render/rtx_types.cpp
+++ b/src/dxvk/rtx_render/rtx_types.cpp
@@ -601,11 +601,7 @@ namespace dxvk {
     }
 
   void BlasEntry::unlinkInstance(RtInstance* instance) {
-    auto it = std::find(m_linkedInstances.begin(), m_linkedInstances.end(), instance);
-    if (it != m_linkedInstances.end()) {
-      std::swap(*it, m_linkedInstances.back());
-      m_linkedInstances.pop_back();
-    } else {
+    if (m_linkedInstances.erase(instance) == 0) {
       ONCE(Logger::err("Tried to unlink an instance, which was never linked!"));
     }
   }

--- a/src/dxvk/rtx_render/rtx_types.h
+++ b/src/dxvk/rtx_render/rtx_types.h
@@ -34,6 +34,7 @@
 #include <inttypes.h>
 #include <memory>
 #include <vector>
+#include <unordered_set>
 #include <future>
 
 using remixapi_MaterialHandle = struct remixapi_MaterialHandle_T*;
@@ -884,12 +885,12 @@ struct BlasEntry {
   }
 
   void linkInstance(RtInstance* instance) {
-    m_linkedInstances.push_back(instance);
+    m_linkedInstances.insert(instance);
   }
 
   void unlinkInstance(RtInstance* instance);
 
-  const std::vector<RtInstance*>& getLinkedInstances() const { return m_linkedInstances; }
+  const std::unordered_set<RtInstance*>& getLinkedInstances() const { return m_linkedInstances; }
 
   void printDebugInfo(const char* name = "") const {
 #ifdef REMIX_DEVELOPMENT
@@ -923,7 +924,13 @@ struct BlasEntry {
   }
 
 private:
-  std::vector<RtInstance*> m_linkedInstances;
+  // Hash set instead of vector: unlink path used to be O(N) (std::find then
+  // swap-and-pop), which became a hot spot when many same-geometry transient
+  // instances share one BlasEntry — end-of-frame GC of N instances ran in
+  // O(N²). Switching to a hash set makes unlink O(1) average. Insertion
+  // ordering doesn't matter for any current consumer (size / empty are the
+  // only read operations on this container).
+  std::unordered_set<RtInstance*> m_linkedInstances;
   std::unordered_map<XXH64_hash_t, LegacyMaterialData> m_materials;
 };
 

--- a/src/dxvk/rtx_render/rtx_types.h
+++ b/src/dxvk/rtx_render/rtx_types.h
@@ -34,6 +34,7 @@
 #include <inttypes.h>
 #include <memory>
 #include <vector>
+#include <unordered_set>
 #include <future>
 
 using remixapi_MaterialHandle = struct remixapi_MaterialHandle_T*;
@@ -908,12 +909,12 @@ struct BlasEntry {
   }
 
   void linkInstance(RtInstance* instance) {
-    m_linkedInstances.push_back(instance);
+    m_linkedInstances.insert(instance);
   }
 
   void unlinkInstance(RtInstance* instance);
 
-  const std::vector<RtInstance*>& getLinkedInstances() const { return m_linkedInstances; }
+  const std::unordered_set<RtInstance*>& getLinkedInstances() const { return m_linkedInstances; }
 
   void printDebugInfo(const char* name = "") const {
 #ifdef REMIX_DEVELOPMENT
@@ -947,7 +948,13 @@ struct BlasEntry {
   }
 
 private:
-  std::vector<RtInstance*> m_linkedInstances;
+  // Hash set instead of vector: unlink path used to be O(N) (std::find then
+  // swap-and-pop), which became a hot spot when many same-geometry transient
+  // instances share one BlasEntry — end-of-frame GC of N instances ran in
+  // O(N²). Switching to a hash set makes unlink O(1) average. Insertion
+  // ordering doesn't matter for any current consumer (size / empty are the
+  // only read operations on this container).
+  std::unordered_set<RtInstance*> m_linkedInstances;
   std::unordered_map<XXH64_hash_t, LegacyMaterialData> m_materials;
 };
 


### PR DESCRIPTION
## Summary

- `BlasEntry::unlinkInstance()` was O(N) (std::find + swap-and-pop on a vector). With many same-geometry transient instances sharing one BlasEntry, end-of-frame GC ran N unlinks at O(N) each — O(N²) per frame.
- Switching `m_linkedInstances` to `std::unordered_set<RtInstance*>` makes unlink O(1) average. `linkInstance` becomes `.insert()`; `unlinkInstance` becomes `.erase()`. No public-API behavior change.
- Present since `98314db1` (Aug 2022). Doesn't bite typical NV target games (Portal RTX, HL2 RTX) because meshes there generally have unique vertex content and don't collide into one BlasEntry via `exactMatch`. Surfaces in games with many same-geometry single-bone draws — Painkiller's FFP indexed-blend skinning is one such pattern, where hundreds of particle billboards emitted from skinned joints share geometry+material and collapse onto one BlasEntry.

## Compatibility

- `getLinkedInstances()` previously returned `const std::vector<RtInstance*>&`. It now returns `const std::unordered_set<RtInstance*>&`.
- All in-tree consumers only use `.size()` (rtx_accel_manager.cpp dynamic-BLAS heuristic, BlasEntry debug print) and `.empty()` (rtx_scene_manager.cpp BVH cache GC predicate). Both work identically on either container.
- No consumer iterates `m_linkedInstances` or depends on insertion order.

## Test plan

- [x] Builds clean on top of latest main (REMIX-5504 included).
- [x] Verified in Painkiller (custom title using dxvk-remix): pre-fix end-of-frame GC scaled quadratically with particle count and caused visible FPS drops in particle-heavy scenes; post-fix the cost is flat with N.
- [ ] CI tests.

## Note on attribution

This O(N²) pattern wasn't introduced by recent commits — it has been latent since the first RTX Remix commit. The first-commit author left a "Swap & pop - faster than 'erase'" comment, indicating awareness of the pop-side cost but not concern about the linear `std::find`. This PR addresses that.