### PR TITLE
NEE Cache: restore reshuffleMaxAge cap

### DIFF
--- a/src/dxvk/shaders/rtx/pass/nee_cache/update_nee_cache.comp.slang
+++ b/src/dxvk/shaders/rtx/pass/nee_cache/update_nee_cache.comp.slang
@@ -51,6 +51,12 @@
 groupshared uint2 s_candidateList[CANDIDATE_LENGTH][BATCH_SIZE];
 groupshared float s_candidateLight[CANDIDATE_LENGTH][BATCH_SIZE];
 groupshared int s_candidateCount[BATCH_SIZE];
+// Per-batch flag set by lane 0 in updateTriangleSample when the cell's
+// reshuffle-age counter has reached reshuffleMaxAge consecutive empty frames.
+// Forces the sample-refresh body to run so stale NEESample entries from
+// previous-frame writes are overwritten with empty samples. Restores the
+// age-bounded preservation that REMIX-5118 deleted; see updateTriangleSample.
+groupshared int s_reshuffleRefresh[BATCH_SIZE];
 
 int convertToThisFramePrefixSumID(int lastID, out int surfaceID, out int primitiveID)
 {
@@ -429,9 +435,50 @@ void updateTriangleSample(NEECell cell, uint2 localIndex, uint3 threadIndex)
   // Update sample
   RNG rng = createRNG(uvec2(threadIndex.xy + threadIndex.z * NEE_CACHE_ELEMENTS * NEE_CACHE_PROBE_RESOLUTION * NEE_CACHE_PROBE_RESOLUTION), cb.frameIdx, threadIndex.z);
 
+  // Per-cell age counter for the empty-cell preservation fallback.
+  //
+  // REMIX-5071 introduced reshuffle resilience: when a cell has no candidates
+  // (e.g. brief BLAS primitive reshuffle), the cached NEESample array from
+  // the previous frame is preserved instead of refreshed, suppressing flicker.
+  //
+  // REMIX-5118 simplified this and inadvertently deleted the age-counter cap
+  // that bounded the preservation window. Without the cap, when an emissive
+  // surface is removed entirely, the cell's candidate count drops to 0
+  // permanently and the cached samples persist indefinitely — stale light
+  // from the removed emissive remains visible "effectively forever".
+  //
+  // Restore the cap: increment a per-cell age counter each frame the cell
+  // has no candidates; reset to 0 when candidates arrive; once the counter
+  // reaches reshuffleMaxAge (and the cap is non-zero), force the refresh
+  // body to run. The body writes NEESample.createEmpty() through the
+  // !candidate.isValid() fall-through, clearing the stale entries.
+  //
+  // Only lane 0 of each batch touches the cell's age field to avoid race;
+  // the resulting refresh decision is broadcast via groupshared memory.
+  // reshuffleMaxAge = 0 honors the documented "disables the limit" semantics.
+  if (cb.neeCacheArgs.enableReshuffleResilience && localIndex.x == 0)
+  {
+    s_reshuffleRefresh[localIndex.y] = 0;
+    if (s_candidateCount[localIndex.y] > 0)
+    {
+      if (cell.getReshuffleAge() != 0)
+        cell.setReshuffleAge(0);
+    }
+    else
+    {
+      uint newAge = min(cell.getReshuffleAge() + 1u, kNeeCacheReshuffleAgeMax);
+      cell.setReshuffleAge(newAge);
+      if (cb.neeCacheArgs.reshuffleMaxAge > 0 && newAge >= cb.neeCacheArgs.reshuffleMaxAge)
+        s_reshuffleRefresh[localIndex.y] = 1;
+    }
+  }
+  GroupMemoryBarrierWithGroupSync();
+
   // This preserves the previous frame's cached samples through brief disruptions
   // (e.g. BLAS primitive reshuffles that break surface mapping for one frame).
-  if (s_candidateCount[localIndex.y] > 0 || !cb.neeCacheArgs.enableReshuffleResilience)
+  // Bounded by the reshuffleMaxAge cap above — once exceeded, the body runs
+  // to overwrite stale samples with empty data.
+  if (s_candidateCount[localIndex.y] > 0 || !cb.neeCacheArgs.enableReshuffleResilience || s_reshuffleRefresh[localIndex.y] != 0)
   {
     for (int i = localIndex.x; i < NEE_CACHE_SAMPLES; i += NEE_CACHE_ELEMENTS)
     {


### PR DESCRIPTION
## Summary

- `rtx.neeCache.reshuffleMaxAge` is dead code on the GPU. The option, ImGui slider, and constant-buffer plumbing all exist, but no shader reads the value.
- The age-counter mechanism that originally enforced this cap (REMIX-5071, commit `5b09970c`) was deleted in REMIX-5118 (commit `0318c0dc`) as part of an unrelated simplification.
- Symptom: with `enableReshuffleResilience=true` (default), removing an emissive surface leaves its cached `NEESample` entries in the cell's `NeeCache` buffer indefinitely. `getCachedLightSample()` keeps serving the stale samples, painting stale illumination on nearby geometry effectively forever. Setting `reshuffleMaxAge` to any value (0, 1, 8) has no effect because the value isn't read.
- This PR restores the per-cell age counter using the bit-layout storage and accessors already reserved in `nee_cache.h:42-44,583,616` — they survived the REMIX-5118 deletion but became unused.

## Mechanism

- Adds `groupshared int s_reshuffleRefresh[BATCH_SIZE]` to `update_nee_cache.comp.slang`.
- In `updateTriangleSample`, lane 0 of each batch:
  - Reads `cell.getReshuffleAge()`.
  - Resets to 0 when `s_candidateCount > 0`.
  - Increments (clamped to `kNeeCacheReshuffleAgeMax = 15`) when `s_candidateCount == 0` and writes back via `setReshuffleAge()`.
  - Sets `s_reshuffleRefresh = 1` when `newAge >= reshuffleMaxAge && reshuffleMaxAge > 0`.
- The body-gate at line 434 is extended to enter when `s_reshuffleRefresh != 0`, forcing the refresh body to run with no candidates. The candidate is `!isValid()` in that path, so the inner loop writes `NEESample.createEmpty()` for every slot, clearing the stale entries.
- Honors the documented "`reshuffleMaxAge = 0` disables the limit" semantics.

## Does not regress REMIX-5118

REMIX-5118 was fixing intermittent dark frames caused by the previous design blocking candidate sampling on reshuffled cells. This PR doesn't bring that back: when candidates are present, the body runs unchanged. Only the **empty-candidate preservation path** is bounded by the cap.

## Verification

In a heavy-BLAS-reshuffle workload (skinned characters, particle effects, frequent emissive instancing):

- `reshuffleMaxAge = 8` (default): stale emissive light clears within ~133 ms (~8 frames at 60 fps).
- `reshuffleMaxAge = 1`: clears in ~17 ms (~1 frame).
- `reshuffleMaxAge = 0`: behavior matches pre-fix — preserved indefinitely, as documented.
- Flicker suppression during BLAS reshuffles still works (the REMIX-5071 use case).

Before this PR, all three `reshuffleMaxAge` settings produced visually identical persistence — clear confirmation the option was dead code on the GPU side.

## Files changed

- `src/dxvk/shaders/rtx/pass/nee_cache/update_nee_cache.comp.slang` — 48 insertions, 1 deletion.

No CPU-side code changes. No new options. Storage and accessors reused.