### PR TITLE
Add build.ps1 + bridge/build.ps1 wrappers and Claude Code build skills

### DIFF
--- a/.claude/skills/bridge-build/SKILL.md
+++ b/.claude/skills/bridge-build/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: bridge-build
+description: Build the Remix Bridge (32-bit client d3d9 + 64-bit server NvRemixBridge) via the bridge/build.ps1 wrapper. Use when the user asks to build, compile, compile-check, smoke-test, or force a clean rebuild of the bridge specifically — the bridge is a separate component from the main runtime and has its own build flow. Reports exit code + verifies artifacts. Do NOT invoke for runtime-side edits (src/) — those are rtx-build's domain.
+---
+
+# bridge-build
+
+Wraps [`bridge/build.ps1`](../../../bridge/build.ps1). The script
+discovers Visual Studio via vswhere, calls vcvarsall.bat by full path
+(avoiding the `bridge/build_common.ps1::SetupVS` silent-failure trap),
+runs `meson setup`/`compile` per arch in isolated cmd.exe shells (no env
+contamination between x64 and x86), and verifies all three expected
+artifacts before reporting success.
+
+The bridge is the IPC layer that lets a 32-bit game talk to the 64-bit
+Remix runtime. Client and server live under `bridge/` and build into
+*separate* meson dirs (one per arch).
+
+## When to invoke
+
+- User asks to build, compile, compile-check, or smoke-test the bridge
+- After a code change that touches `bridge/src/client/`,
+  `bridge/src/server/`, `bridge/src/util/`, `bridge/src/launcher/`,
+  or any IPC opcode/struct shared between client and server
+- After a `public/include/remix/remix_c.h` change that affects the
+  Remix C API surface (the bridge consumes that header)
+- Before pushing changes that touch the bridge
+
+## When NOT to invoke
+
+- Edits only under `src/` or other runtime-side code — that's
+  `rtx-build`'s domain
+- Doc-only changes (`bridge/README.md`, `.md`, etc.)
+- Skill / settings / config edits
+- When the user asks for the main runtime build — invoke `rtx-build`
+  instead
+
+## Steps
+
+1. From the project root, kick off the build with
+   `run_in_background: true` (expected duration: ~30s incremental,
+   2-4 min cold full for both arches):
+
+   ```powershell
+   & .\bridge\build.ps1
+   ```
+
+   For non-default flavor: `-Flavor debug` or `-Flavor debugoptimized`.
+   For single-arch: `-Arch x64` or `-Arch x86`. Add `-Clean` to wipe
+   the matching `_comp*` dir(s) first.
+
+2. Wait for the task-completion notification — DO NOT poll, the
+   runtime will wake you up when the background command exits.
+
+3. Report back:
+   - **Green (exit 0):** the script's own output ends with
+     `=== Bridge build OK ===` and prints all three artifacts
+     (x64 server, x86 client, x86 launcher) with mtimes. Quote those
+     lines.
+   - **Mixed-date warning:** if x64 server and x86 client mtimes are
+     from different commits, flag this — IPC ABI risk if the command
+     opcodes/structs in `bridge/src/util/` shifted between commits.
+   - **Red (non-zero exit):** scan the captured output for
+     `error C[0-9]`, `FAILED:`, `ninja: build stopped`. Quote the
+     first ~10 error lines verbatim.
+
+## Flavors
+
+| Flavor | `--buildtype` | Build dirs |
+|---|---|---|
+| release (default) | `release` | `_compRelease_x64`, `_compRelease_x86` |
+| debug | `debug` | `_compDebug_x64`, `_compDebug_x86` |
+| debugoptimized | `debugoptimized` | `_compDebugOptimized_x64`, `_compDebugOptimized_x86` |
+
+## Output layout
+
+After a successful build, deployable binaries live in `bridge/_output/`:
+
+```
+bridge/_output/
+├── d3d9.dll                    ← x86 client (canonical name; deploy AS-IS)
+├── NvRemixLauncher32.exe       ← x86 injection launcher
+├── d3d9.lib, d3d9.exp          ← link artifacts (not needed at runtime)
+└── .trex/
+    └── NvRemixBridge.exe       ← x64 server
+```
+
+> **PDBs may go stale.** The `copy_d3d9_to_output` custom_target globs
+> `d3d9*` but in practice the linker may emit the .pdb after the copy
+> step has already run, leaving stale debug symbols in `_output/`. If
+> you need fresh symbols (crash analysis, dump inspection), copy
+> `_compRelease_x86/src/client/d3d9.pdb` to `_output/d3d9.pdb`
+> manually after the build.
+
+## Gotchas
+
+- **Don't bypass the script** by calling `build_bridge_release.bat`
+  (or `_debug.bat`, `_all.bat`, etc.) directly. Under any subprocess
+  context where the parent shell hasn't already loaded VS env, the
+  .bat's `SetupVS`/vcvarsall lookup silently fails, the .bat exits 0
+  with no x86 build output, and the .bat's empty captured stdout
+  (`cmd.exe /c` stdio quirk) hides the failure. `bridge/build.ps1`
+  was written specifically to fix that trap.
+- **Two separate build dirs.** Unlike rtx-build (single dir), the
+  bridge has `_compRelease_x64` (server only) and `_compRelease_x86`
+  (client + launcher). Ninja runs against each independently — one
+  side can rebuild while the other is a no-op when sources match.
+- **MSVC v142 toolchain required.** Either VS2019 directly, or
+  VS2022 with the v142 toolset Individual Component installed.
+  The script's vswhere call uses `-version '[16.0,18.0)'` so either
+  works.
+- **`gametargets.conf` deploy path.** If the user has set up
+  `bridge/gametargets.conf`, meson auto-deploys binaries into the
+  configured game dirs as part of the build. The bridge's
+  `gametargets.conf` output dir should be the *parent* of the
+  `.trex/` folder (unlike the main runtime's gametargets, which
+  points AT `.trex/`).
+- **Bridge can run standalone** (without the main `dxvk-remix`
+  runtime). In that case it falls back to system d3d9.dll — no
+  pathtracing, but useful for IPC smoke tests.

--- a/.claude/skills/rtx-build/SKILL.md
+++ b/.claude/skills/rtx-build/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: rtx-build
+description: Build the dxvk-remix runtime (64-bit d3d9.dll) via the repo-root build.ps1 wrapper. Use when the user asks to build, compile, compile-check, verify, or smoke-test the runtime. Runs in the background, reports exit code + verifies artifacts. Do NOT invoke for doc/skill/config-only edits — those don't affect compilation.
+---
+
+# rtx-build
+
+Wraps [`build.ps1`](../../../build.ps1) at the repo root. The script
+discovers Visual Studio via vswhere, calls vcvarsall.bat by full path
+(avoiding the `build_common.ps1::SetupVS` silent-failure trap), runs
+`meson setup`/`compile`/`install` in a single isolated cmd.exe shell,
+and verifies build artifacts exist before reporting success.
+
+## When to invoke
+
+- User asks to build, compile, compile-check, verify, or smoke-test
+- Before pushing code changes
+- After a code change that touches runtime sources under `src/`,
+  `include/`, or `public/`
+
+## When NOT to invoke
+
+- Doc-only changes (`.md`, `documentation/`, `.claude/`) — no
+  compile impact
+- Skill / settings / config edits
+- Bridge-only changes — invoke `bridge-build` instead
+- Before the user has finished their code edits — building against a
+  work-in-progress tree wastes time
+
+## Steps
+
+1. From the project root, kick off the build with
+   `run_in_background: true` (expected duration: ~30s incremental,
+   10-15 min cold full):
+
+   ```powershell
+   & .\build.ps1
+   ```
+
+   For non-default flavor, add `-Flavor debug` or
+   `-Flavor debugoptimized`. Add `-Clean` to wipe the build dir
+   first. Add `-EnableTracy` to enable the Tracy profiler.
+
+2. Wait for the task-completion notification — DO NOT poll, the
+   runtime will wake you up when the background command exits.
+
+3. Report back:
+   - **Green (exit 0):** the script's own output ends with
+     `=== Runtime build OK ===` and prints the artifact paths +
+     mtimes. Quote those lines.
+   - **Red (non-zero exit):** scan the captured output for
+     `error C[0-9]`, `fatal error`, `FAILED:`, `ninja: build stopped`,
+     or `Failed to run`. Quote the first ~10 error lines so the user
+     sees the real cause before any fix attempt.
+
+## Flavors
+
+| Flavor | `--buildtype` | Build dir |
+|---|---|---|
+| release (default) | `release` | `_Comp64Release` |
+| debug | `debug` | `_Comp64Debug` |
+| debugoptimized | `debugoptimized` | `_Comp64DebugOptimized` |
+
+## Gotchas
+
+- **`LNK4098: defaultlib 'LIBCMT' conflicts`** is a pre-existing
+  warning, not a failure.
+- **`WARNING: msvc does not support C++11; attempting best effort`**
+  is upstream noise, not a failure.
+- **Build produces `d3d9.dll`** in `_Comp64Release/src/d3d9/` and
+  installs it to `_output/`, `public/bin/`, and the test app dirs.
+- **Don't bypass the script** by calling `build_common.ps1::PerformBuild`
+  directly. It works, but its `SetupVS` function lies about success
+  when vcvarsall.bat lookup fails — invisible until the next
+  consumer hits a stale build. `build.ps1` is the audited entry
+  point that doesn't have that trap.
+- **Optional auto-deploy:** drop an `auto-deploy.local.ps1` at the
+  repo root (gitignored) that sets `$AutoDeployTargets = @('C:\path\to\game\.trex')`.
+  The build will copy `_output/d3d9.dll` to each listed path after a
+  successful build.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ metrics.txt
 nrc_session_log.txt
 python.dxvk-cache
 *.xml.user
+/auto-deploy.local.ps1

--- a/bridge/build.ps1
+++ b/bridge/build.ps1
@@ -1,0 +1,139 @@
+#requires -version 5.1
+<#
+.SYNOPSIS
+  Build the Remix Bridge (32-bit client + 64-bit server) reliably.
+
+.DESCRIPTION
+  PowerShell wrapper around the meson/ninja bridge build. Discovers
+  Visual Studio via vswhere, calls vcvarsall.bat by full path, and runs
+  meson setup + compile per arch in isolated cmd.exe shells (no env
+  contamination between x64 and x86). Streams output to the PowerShell
+  pipeline so progress and errors are visible. Throws on any non-zero
+  exit and verifies the expected build artifacts exist before reporting
+  success.
+
+  Resolves the failure mode in bridge/build_common.ps1::SetupVS where a
+  missing C++ workload silently no-ops: cmd writes "'vcvarsall.bat' is
+  not recognized" to stderr, the piped `set` dumps the existing env,
+  the ForEach loop re-sets the same vars, and the script proceeds with
+  no VC env loaded. Under build_bridge_release.bat the failure further
+  hides because the .bat captures cmd's empty stdout and exits 0 with
+  no client output.
+
+.PARAMETER Flavor
+  release (default), debug, debugoptimized.
+
+.PARAMETER Arch
+  x64, x86, or both (default).
+
+.PARAMETER Clean
+  Wipe the matching _comp* dir(s) before building.
+
+.EXAMPLE
+  .\bridge\build.ps1
+  .\bridge\build.ps1 -Arch x86 -Clean
+  .\bridge\build.ps1 -Flavor debugoptimized -Arch both
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('release','debug','debugoptimized')]
+    [string]$Flavor = 'release',
+
+    [ValidateSet('x64','x86','both')]
+    [string]$Arch = 'both',
+
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+$BridgeRoot = $PSScriptRoot
+$flavorTag = switch ($Flavor) {
+    'release'        { 'Release' }
+    'debug'          { 'Debug' }
+    'debugoptimized' { 'DebugOptimized' }
+}
+$buildDirPrefix = "_comp$flavorTag"
+
+# --- Discover Visual Studio ---
+$vsWhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path $vsWhere)) {
+    throw "vswhere.exe not found at '$vsWhere'. Install the Visual Studio Installer (ships with VS2017+)."
+}
+$vsPath = & $vsWhere -latest -version '[16.0,18.0)' -property installationPath
+if ([string]::IsNullOrWhiteSpace($vsPath)) {
+    throw "No Visual Studio 2019 or 2022 installation with v142 toolchain found via vswhere."
+}
+$vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvarsall.bat'
+if (-not (Test-Path $vcvars)) {
+    throw "vcvarsall.bat not found at '$vcvars'. The detected VS install may be incomplete (missing C++ build tools workload)."
+}
+
+Write-Host "VS install:  $vsPath"  -ForegroundColor DarkGray
+Write-Host "vcvars:      $vcvars"   -ForegroundColor DarkGray
+Write-Host "Bridge root: $BridgeRoot" -ForegroundColor DarkGray
+Write-Host "Flavor:      $Flavor / $Arch" -ForegroundColor DarkGray
+
+$arches = if ($Arch -eq 'both') { @('x64','x86') } else { @($Arch) }
+
+Set-Location $BridgeRoot
+
+foreach ($a in $arches) {
+    $buildDir = "${buildDirPrefix}_$a"
+    Write-Host ""
+    Write-Host "=== Bridge $a $Flavor -> $buildDir ===" -ForegroundColor Cyan
+
+    if ($Clean -and (Test-Path $buildDir)) {
+        Write-Host "Wiping $buildDir for clean rebuild..." -ForegroundColor Yellow
+        Remove-Item -Path $buildDir -Recurse -Force
+    }
+
+    $alreadyConfigured = Test-Path (Join-Path $buildDir 'meson-private')
+    if ($alreadyConfigured) {
+        # meson auto-reconfigures from inside the build dir if meson.build changed
+        $chain = "call `"$vcvars`" $a >nul 2>&1 && cd $buildDir && meson compile"
+    } else {
+        $chain = "call `"$vcvars`" $a >nul 2>&1 && meson setup --buildtype $Flavor --backend ninja $buildDir && cd $buildDir && meson compile"
+    }
+
+    # Native-command stderr triggers PowerShell's NativeCommandError under
+    # EAP=Stop even on exit 0. Exit code is the authoritative signal here.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        cmd.exe /c $chain
+        $exit = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if ($exit -ne 0) {
+        throw "Bridge $a $Flavor build failed (exit $exit)."
+    }
+}
+
+# Sanity-check artifacts so the caller can trust exit 0
+$expected = @{}
+if ($arches -contains 'x64') {
+    $expected["${buildDirPrefix}_x64/src/server/NvRemixBridge.exe"] = 'x64 server'
+}
+if ($arches -contains 'x86') {
+    $expected["${buildDirPrefix}_x86/src/client/d3d9.dll"]            = 'x86 client'
+    $expected["${buildDirPrefix}_x86/src/launcher/NvRemixLauncher32.exe"] = 'x86 launcher'
+}
+
+$missing = @()
+foreach ($rel in $expected.Keys) {
+    $abs = Join-Path $BridgeRoot $rel
+    if (-not (Test-Path $abs)) { $missing += "$($expected[$rel]) ($rel)" }
+}
+if ($missing.Count -gt 0) {
+    throw "Build reported success but artifacts are missing: $($missing -join ', ')"
+}
+
+Write-Host ""
+Write-Host "=== Bridge build OK ===" -ForegroundColor Green
+foreach ($rel in $expected.Keys) {
+    $abs = Join-Path $BridgeRoot $rel
+    $info = Get-Item $abs
+    Write-Host ("  {0,-14} {1:yyyy-MM-dd HH:mm}  {2,10:N0} bytes  {3}" -f $expected[$rel], $info.LastWriteTime, $info.Length, $rel) -ForegroundColor Green
+}

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,174 @@
+#requires -version 5.1
+<#
+.SYNOPSIS
+  Build the dxvk-remix runtime (64-bit d3d9.dll) reliably.
+
+.DESCRIPTION
+  PowerShell wrapper around the meson/ninja runtime build. Discovers
+  Visual Studio via vswhere, calls vcvarsall.bat by full path, and runs
+  meson setup + compile + install in a single isolated cmd.exe shell so
+  VS env stays consistent across steps. Streams output to the PowerShell
+  pipeline so progress and errors are visible. Throws on any non-zero
+  exit and verifies the expected build artifacts exist before reporting
+  success.
+
+  Resolves the failure mode in build_common.ps1::SetupVS where a missing
+  C++ workload silently no-ops: cmd writes "'vcvarsall.bat' is not
+  recognized" to stderr, the piped `set` dumps the existing env, the
+  ForEach loop re-sets the same vars, and the script proceeds with no
+  VC env loaded. meson then surfaces a cryptic "cl.exe not found"
+  downstream, hiding the real cause.
+
+.PARAMETER Flavor
+  release (default), debug, debugoptimized.
+
+.PARAMETER EnableTracy
+  Enable Tracy profiler integration (-Denable_tracy=true).
+
+.PARAMETER Clean
+  Wipe the matching _Comp64* dir before building.
+
+.EXAMPLE
+  .\build.ps1
+  .\build.ps1 -Flavor debugoptimized
+  .\build.ps1 -Clean -EnableTracy
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('release','debug','debugoptimized')]
+    [string]$Flavor = 'release',
+
+    [switch]$EnableTracy,
+
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = $PSScriptRoot
+$flavorTag = switch ($Flavor) {
+    'release'        { 'Release' }
+    'debug'          { 'Debug' }
+    'debugoptimized' { 'DebugOptimized' }
+}
+$buildDir = "_Comp64$flavorTag"
+$tracyFlag = if ($EnableTracy) { 'true' } else { 'false' }
+
+# --- Discover Visual Studio ---
+$vsWhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path $vsWhere)) {
+    throw "vswhere.exe not found at '$vsWhere'. Install the Visual Studio Installer (ships with VS2017+)."
+}
+$vsPath = & $vsWhere -latest -version '[16.0,18.0)' -property installationPath
+if ([string]::IsNullOrWhiteSpace($vsPath)) {
+    throw "No Visual Studio 2019 or 2022 installation with v142 toolchain found via vswhere."
+}
+$vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvarsall.bat'
+if (-not (Test-Path $vcvars)) {
+    throw "vcvarsall.bat not found at '$vcvars'. The detected VS install may be incomplete (missing C++ build tools workload)."
+}
+
+Write-Host "VS install: $vsPath"  -ForegroundColor DarkGray
+Write-Host "vcvars:     $vcvars"   -ForegroundColor DarkGray
+Write-Host "Repo root:  $RepoRoot" -ForegroundColor DarkGray
+Write-Host "Build dir:  $buildDir" -ForegroundColor DarkGray
+Write-Host "Tracy:      $tracyFlag" -ForegroundColor DarkGray
+
+Set-Location $RepoRoot
+
+# Pre-cleanup. nv-private/ and tests/rtx/dxvk_rt_testing/ are untracked
+# install targets that meson regenerates on every install. A stale copy
+# left over from a prior build can confuse the next install pass into
+# copying or referencing the wrong files. Known-issue workaround.
+Remove-Item -Path .\nv-private -Recurse -Force -Confirm:$false -ErrorAction SilentlyContinue
+Remove-Item -Path .\tests\rtx\dxvk_rt_testing -Recurse -Force -Confirm:$false -ErrorAction SilentlyContinue
+
+if ($Clean -and (Test-Path $buildDir)) {
+    Write-Host "Wiping $buildDir for clean rebuild..." -ForegroundColor Yellow
+    Remove-Item -Path $buildDir -Recurse -Force
+}
+
+Write-Host ""
+Write-Host "=== Runtime $Flavor -> $buildDir ===" -ForegroundColor Cyan
+
+$alreadyConfigured = Test-Path (Join-Path $buildDir 'meson-private')
+if ($alreadyConfigured) {
+    # meson auto-reconfigures from inside the build dir if meson.build changed
+    $chain = "call `"$vcvars`" x64 >nul 2>&1 && cd $buildDir && meson compile -v && meson install"
+} else {
+    $chain = "call `"$vcvars`" x64 >nul 2>&1 && meson setup --buildtype $Flavor --backend ninja -Denable_tracy=$tracyFlag $buildDir && cd $buildDir && meson compile -v && meson install"
+}
+
+# Native-command stderr triggers PowerShell's NativeCommandError under
+# EAP=Stop even on exit 0. Exit code is the authoritative signal here.
+$prevEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    cmd.exe /c $chain
+    $exit = $LASTEXITCODE
+} finally {
+    $ErrorActionPreference = $prevEAP
+}
+if ($exit -ne 0) {
+    throw "Runtime $Flavor build failed (exit $exit)."
+}
+
+# Sanity-check artifacts so the caller can trust exit 0
+$artifacts = @{
+    "$buildDir/src/d3d9/d3d9.dll" = 'runtime DLL (build dir)'
+    '_output/d3d9.dll'            = 'runtime DLL (deploy)'
+}
+
+$missing = @()
+foreach ($rel in $artifacts.Keys) {
+    $abs = Join-Path $RepoRoot $rel
+    if (-not (Test-Path $abs)) { $missing += "$($artifacts[$rel]) ($rel)" }
+}
+if ($missing.Count -gt 0) {
+    throw "Build reported success but artifacts are missing: $($missing -join ', ')"
+}
+
+Write-Host ""
+Write-Host "=== Runtime build OK ===" -ForegroundColor Green
+foreach ($rel in $artifacts.Keys) {
+    $abs = Join-Path $RepoRoot $rel
+    $info = Get-Item $abs
+    Write-Host ("  {0,-24} {1:yyyy-MM-dd HH:mm}  {2,12:N0} bytes  {3}" -f $artifacts[$rel], $info.LastWriteTime, $info.Length, $rel) -ForegroundColor Green
+}
+
+# --- Optional auto-deploy to user-local game install paths ---
+#
+# If `auto-deploy.local.ps1` exists at the repo root (gitignored),
+# dot-source it and copy `_output/d3d9.dll` to each path listed in
+# `$AutoDeployTargets`. Lets contributors skip the manual copy/paste
+# into their test game install without leaking machine-specific paths
+# into the tracked tree.
+#
+# Local file template:
+#   $AutoDeployTargets = @(
+#     'C:\path\to\game\.trex'
+#   )
+$autoDeployScript = Join-Path $RepoRoot 'auto-deploy.local.ps1'
+if (Test-Path $autoDeployScript) {
+    $AutoDeployTargets = @()
+    . $autoDeployScript
+    if ($AutoDeployTargets.Count -gt 0) {
+        Write-Host ""
+        Write-Host "=== Auto-deploy (from auto-deploy.local.ps1) ===" -ForegroundColor Cyan
+        $sourceDll = Join-Path $RepoRoot '_output/d3d9.dll'
+        foreach ($target in $AutoDeployTargets) {
+            if (-not (Test-Path $target)) {
+                Write-Host "  SKIP (target dir missing): $target" -ForegroundColor Yellow
+                continue
+            }
+            $destDll = Join-Path $target 'd3d9.dll'
+            try {
+                Copy-Item -Path $sourceDll -Destination $destDll -Force
+                $info = Get-Item $destDll
+                Write-Host ("  copied -> {0:yyyy-MM-dd HH:mm}  {1,12:N0} bytes  {2}" -f $info.LastWriteTime, $info.Length, $destDll) -ForegroundColor Green
+            } catch {
+                Write-Host "  FAIL: $target -- $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    }
+}


### PR DESCRIPTION
As promised, here are the Claude build skills from Remix Plus. This also includes a fix for a common issue people run into in the main build script.

## Summary

Adds `build.ps1` (runtime) and `bridge/build.ps1` (bridge) — PowerShell wrappers around the existing meson/ninja build flow that address two known build issues:

1. **Stale install-target directories.** The runtime install writes to `nv-private/` and `tests/rtx/dxvk_rt_testing/`. Stale content left in those directories from a prior build can cause subsequent installs to behave incorrectly. `build.ps1` pre-clears both before every install — this is the load-bearing fix the wrapper exists for.
2. **Silent `SetupVS` failure.** When the detected Visual Studio install is missing the C++ build tools workload, `vcvarsall.bat` lookup silently no-ops (`cmd` writes `'vcvarsall.bat' is not recognized` to stderr, but the script continues with no VC env loaded); meson then surfaces a cryptic `cl.exe not found` later, hiding the real cause. Under `build_bridge_release.bat` it's worse — the .bat captures `cmd`'s empty stdout and exits `0` with no x86 client output. The wrappers resolve `vcvarsall.bat` by full path with a `Test-Path` guard, so the missing workload fails loudly at the wrapper instead.

Plus two `.claude/skills/` files documenting the canonical invocation for LLM-driven contributor workflows.

Both wrappers are additive — `build_dxvk.ps1`, `build_common.ps1`, and `bridge/build_bridge_*.bat` are untouched, so existing CI and docs keep working.

## What the wrappers do

- **Pre-clear `nv-private/` and `tests/rtx/dxvk_rt_testing/`** before each runtime build. These are untracked install-target directories that meson regenerates; stale content there causes the issue called out above. Known-issue workaround.
- **Resolve Visual Studio via `vswhere`** and `Test-Path`-validate the install before doing anything else.
- **Invoke `vcvarsall.bat` by full path** (`call "$vcvars"`) so a missing C++ workload fails loudly at the wrapper, not later in meson.
- **Run `meson setup` / `compile` / `install` in a single isolated `cmd.exe` shell** so VS env stays consistent across the chain.
- **Stream output** to the PowerShell pipeline.
- **Verify expected build artifacts exist** before reporting success.
- **Optional `auto-deploy.local.ps1`** at repo root (gitignored) for contributors who want successful builds copied to a test game install. No-op when the file doesn't exist.

## Parameters

`build.ps1`: `-Flavor release|debug|debugoptimized`, `-EnableTracy`, `-Clean`

`bridge/build.ps1`: `-Flavor release|debug|debugoptimized`, `-Arch x64|x86|both` (default `both`), `-Clean`

## Skills

`.claude/skills/{rtx-build,bridge-build}/SKILL.md` are content files consumed by Claude Code / similar LLM tooling. They document the canonical invocation, when to invoke (and when not to), expected duration, success / error report patterns, and known-non-failure warnings (`LNK4098`, etc.). No effect on the build itself.

## Testing

Tested against a fresh shallow clone of `main` with all submodules at `--depth=1 --init --recursive`:

| Run | Result |
|---|---|
| `build.ps1 -Flavor release` cold | green, both artifacts produced |
| `build.ps1 -Flavor release` 2nd pass | green |
| `build.ps1 -Flavor release` 3rd pass with cleanup active | green — install dirs regenerated cleanly after pre-clear |
| `bridge/build.ps1 -Flavor release -Arch both` cold | green, all three artifacts (x64 server, x86 client, x86 launcher) |
| `bridge/build.ps1 -Flavor release -Arch both` 2nd pass | green |

Zero compile errors, zero linker errors, zero matches for `error C\d|fatal error|FAILED:|ninja: build stopped|cl\.exe not found|vcvarsall.*not recognized`.

