### PR TITLE
Use full fp32 for direction and orientation on distant lights

### DIFF
--- a/src/dxvk/rtx_render/rtx_lights.cpp
+++ b/src/dxvk/rtx_render/rtx_lights.cpp
@@ -850,31 +850,28 @@ void RtDistantLight::applyTransform(const Matrix4& lightToWorld) {
 void RtDistantLight::writeGPUData(unsigned char* data, std::size_t& offset) const {
   [[maybe_unused]] const std::size_t oldOffset = offset;
 
-  assert(m_direction < Vector3(FLOAT16_MAX));
-  writeGPUHelper(data, offset, glm::packHalf1x16(m_direction.x));
-  writeGPUHelper(data, offset, glm::packHalf1x16(m_direction.y));
-  writeGPUHelper(data, offset, glm::packHalf1x16(m_direction.z));
+  // Direction and orientation are stored as full float32 (not float16): float16's coarse angular
+  // precision quantizes small direction changes to the same value, causing shadows to snap/step
+  // instead of moving smoothly on slowly animated distant (sun) lights.
 
   // Note: Ensure the orientation quaternion is normalized as this is a requirement for the GPU encoding.
   assert(isApproxNormalized(m_orientation, kNormalizationThreshold));
-  assert(m_orientation < Vector4(FLOAT16_MAX));
-  // Note: Orientation could be more heavily packed (down to snorms, or even other quaternion memory encodings), but
-  // there is enough space that no fancy encoding which would just waste performance on the GPU side is needed.
-  writeGPUHelper(data, offset, glm::packHalf1x16(m_orientation.x));
-  writeGPUHelper(data, offset, glm::packHalf1x16(m_orientation.y));
-  writeGPUHelper(data, offset, glm::packHalf1x16(m_orientation.z));
-  writeGPUHelper(data, offset, glm::packHalf1x16(m_orientation.w));
-
-  writeGPUPadding<2>(data, offset);
+  writeGPUHelper(data, offset, m_orientation.x);
+  writeGPUHelper(data, offset, m_orientation.y);
+  writeGPUHelper(data, offset, m_orientation.z);
+  writeGPUHelper(data, offset, m_orientation.w);
 
   writeGPUHelper(data, offset, packLogLuv32(m_radiance));
   writeGPUPadding<12>(data, offset); // no shaping
 
+  assert(isApproxNormalized(m_direction, kNormalizationThreshold));
+  writeGPUHelper(data, offset, m_direction.x);
+  writeGPUHelper(data, offset, m_direction.y);
+  writeGPUHelper(data, offset, m_direction.z);
+  writeGPUPadding<4>(data, offset);
+
   writeGPUHelper(data, offset, m_cosHalfAngle);
   writeGPUHelper(data, offset, m_sinHalfAngle);
-
-  // Note: Unused space for distant lights
-  writeGPUPadding<16>(data, offset);
 
   writeGPUDataVolumetricRadianceScale(data, oldOffset, offset, m_volumetricRadianceScale);
 

--- a/src/dxvk/shaders/rtx/concept/light/distant_light.slangh
+++ b/src/dxvk/shaders/rtx/concept/light/distant_light.slangh
@@ -30,22 +30,10 @@ DistantLight distantLightCreate(DecodedPolymorphicLight decodedPolymorphicLight)
 
   DistantLight distantLight;
 
-  const u16vec2 data00 = unpack16(decodedPolymorphicLight.data0.x);
-  const u16vec2 data01 = unpack16(decodedPolymorphicLight.data0.y);
-  const u16vec2 data02 = unpack16(decodedPolymorphicLight.data0.z);
-  const u16vec2 data03 = unpack16(decodedPolymorphicLight.data0.w);
-  const uint32_t data20 = decodedPolymorphicLight.data2.x;
-  const uint32_t data21 = decodedPolymorphicLight.data2.y;
-
-  distantLight.direction = vec3(uint16BitsToF32(data00.x), uint16BitsToF32(data00.y), uint16BitsToF32(data01.x));
-  distantLight.orientation = vec4(
-    uint16BitsToF32(data01.y),
-    uint16BitsToF32(data02.x),
-    uint16BitsToF32(data02.y),
-    uint16BitsToF32(data03.x));
-  // Note: data03.y unused
-  distantLight.cosHalfAngle = uintBitsToFloat(data20);
-  distantLight.sinHalfAngle = uintBitsToFloat(data21);
+  distantLight.orientation = uintBitsToFloat(decodedPolymorphicLight.data0);
+  distantLight.direction = uintBitsToFloat(decodedPolymorphicLight.data2.xyz);
+  distantLight.cosHalfAngle = uintBitsToFloat(decodedPolymorphicLight.data3.x);
+  distantLight.sinHalfAngle = uintBitsToFloat(decodedPolymorphicLight.data3.y);
   distantLight.radiance = decodedPolymorphicLight.radiance;
 
   return distantLight;


### PR DESCRIPTION
This PR fixes: https://github.com/NVIDIAGameWorks/rtx-remix/issues/1061

_____

Always write distant-light direction and orientation as float32 instead of float16.

Changes:
- `rtx_render\rtx_lights.cpp :: RtDistantLight::writeGPUData`): direction and orientation are written as fp32
- `shaders\rtx\concept\light\distant_light.slangh :: distantLightCreate`): no more unpacking - direct bits to float copies

no layout / size changes (still 64 bytes)
  - data0 -- orientation (fp32)
  - data1.x -- radiance (unchanged)
  - data2.xyz -- direction (fp32)
  - data3.x/.y -- moved cos/sin half-angle from data2 to data3
