### PR TITLE
Add a per-frame triangle budget for new geometry materialization

### DIFF
--- a/src/dxvk/rtx_render/rtx_draw_call_cache.cpp
+++ b/src/dxvk/rtx_render/rtx_draw_call_cache.cpp
@@ -46,12 +46,15 @@ DrawCallCache::DrawCallCache(DxvkDevice* device) : CommonDeviceObject(device) {
 }
 DrawCallCache::~DrawCallCache() {}
 
-DrawCallCache::CacheState DrawCallCache::get(const DrawCallState& drawCall, BlasEntry** out) {
+DrawCallCache::CacheState DrawCallCache::get(const DrawCallState& drawCall, BlasEntry** out, bool allowAllocate) {
   // First, find the right bucket:
   const XXH64_hash_t hash = drawCall.getGeometryData().getHashForRule<rules::TopologicalHash>();
   auto range = m_entries.equal_range(hash);
   if (range.first == m_entries.end()) {
     // New bucket
+    if (!allowAllocate) {
+      return CacheState::kRejectedBudget;
+    }
     *out = allocateEntry(hash, drawCall);
     return CacheState::kNew;
   }
@@ -76,6 +79,9 @@ DrawCallCache::CacheState DrawCallCache::get(const DrawCallState& drawCall, Blas
     } else {
       // First frame of having two mismatching instances, and the first instance has already 
       // been paired with the existing BlasEntry.
+      if (!allowAllocate) {
+        return CacheState::kRejectedBudget;
+      }
       *out = allocateEntry(hash, drawCall);
       return CacheState::kNew;
     }
@@ -120,6 +126,9 @@ DrawCallCache::CacheState DrawCallCache::get(const DrawCallState& drawCall, Blas
   }
   if (*out == nullptr) {
     // Failed to find similar blas, so allocate a new one
+    if (!allowAllocate) {
+      return CacheState::kRejectedBudget;
+    }
     *out = allocateEntry(hash, drawCall);
     return CacheState::kNew;
   }

--- a/src/dxvk/rtx_render/rtx_draw_call_cache.h
+++ b/src/dxvk/rtx_render/rtx_draw_call_cache.h
@@ -46,6 +46,9 @@ public:
   {
     kNew = 0,
     kExisted = 1,
+    // Lookup missed and allocation was disallowed (materialization budget
+    // exhausted this frame) — no entry was created, *out is nullptr.
+    kRejectedBudget = 2,
   };
 
   DrawCallCache(DrawCallCache const&) = delete;
@@ -54,7 +57,7 @@ public:
   explicit DrawCallCache(DxvkDevice* device);
   ~DrawCallCache();
 
-  CacheState get(const DrawCallState& drawCall, BlasEntry** out);
+  CacheState get(const DrawCallState& drawCall, BlasEntry** out, bool allowAllocate = true);
 
   MultimapType& getEntries() {return m_entries;}
 

--- a/src/dxvk/rtx_render/rtx_options.h
+++ b/src/dxvk/rtx_render/rtx_options.h
@@ -629,6 +629,15 @@ namespace dxvk {
     RTX_OPTION_ENV("rtx", bool, adaptiveAccumulation, true, "DXVK_USE_ADAPTIVE_ACCUMULATION", "");
     RTX_OPTION("rtx", uint32_t, numFramesToKeepInstances, 1, "");
     RTX_OPTION("rtx", uint32_t, numFramesToKeepBLAS, 1, "");
+    RTX_OPTION("rtx", uint32_t, materializationBudgetTrianglesPerFrame, 0,
+               "When > 0, bounds the triangles of NEW geometry materialized (uploaded + BLAS-built) per frame.\n"
+               "New geometry is admitted while the frame's running total is under the budget; the final "
+               "admission may overshoot by one mesh, so a single mesh larger than the budget still loads. "
+               "Over-budget draws are skipped statelessly and retried on following frames: original draws "
+               "via the game's own resubmission, replacement prims via the ReplacementInstance "
+               "pendingMaterialization flag, which bypasses the preserve path until every prim materialized. "
+               "Trades a brief pop-in at the frustum edge for the frame spike a burst of newly-visible "
+               "geometry otherwise causes. 0 = unlimited (legacy behavior).");
     RTX_OPTION("rtx", uint32_t, numFramesToKeepLights, 100, ""); // NOTE: This was the default we've had for a while, can probably be reduced...
     RTX_OPTION("rtx", uint32_t, sceneKeepAliveFrames, 0, 
                "Number of consecutive frames without valid camera or raytracing before clearing the scene."

--- a/src/dxvk/rtx_render/rtx_scene_manager.cpp
+++ b/src/dxvk/rtx_render/rtx_scene_manager.cpp
@@ -518,6 +518,7 @@ namespace dxvk {
 
     m_cameraManager.onFrameEnd();
     m_instanceManager.onFrameEnd();
+    m_materializedTrianglesThisFrame = 0;
     m_previousFrameSceneAvailable = raytracedThisFrame && RtxOptions::enablePreviousTLAS();
 
     m_bufferCache.clear();
@@ -714,6 +715,7 @@ namespace dxvk {
     const bool usePreservePath =
         RtxOptions::enablePreservePath() &&
         replacementInstance->dirtyFlags.isClear() &&
+        !replacementInstance->pendingMaterialization &&
         !RtxOptionManager::isDrawcallTranslationInvalid() &&
         !secondSubmissionThisFrame &&
         !input.getCategoryFlags().test(InstanceCategories::ParticleEmitter) &&
@@ -746,6 +748,7 @@ namespace dxvk {
 
         RtInstance* instance = processDrawCallState(ctx, input, renderMaterialData,
             *replacementInstance, existingInstance, nullptr);
+        replacementInstance->pendingMaterialization = m_lastDrawDeferredByBudget;
         if (instance != nullptr) {
           if (replacementInstance->root.getUntyped() == nullptr) {
             replacementInstance->setup(PrimInstance(instance, PrimInstance::Type::Instance), 1, nullptr);
@@ -917,6 +920,8 @@ namespace dxvk {
       return replacementInstance->prims[idx].getInstance();
     };
 
+    bool anyPrimDeferredByBudget = false;
+
     for (size_t i = 0; i < pReplacements->size(); i++) {
       auto& replacement = (*pReplacements)[i];
       RtInstance* instance = nullptr;
@@ -932,6 +937,7 @@ namespace dxvk {
 
         const RtxParticleSystemDesc* pParticleSystemDesc = replacement.particleSystem.has_value() ? &replacement.particleSystem.value() : nullptr;
         instance = processDrawCallState(ctx, *newDrawCallState, renderMaterialData, *replacementInstance, getExistingInstance(i), pParticleSystemDesc);
+        anyPrimDeferredByBudget |= m_lastDrawDeferredByBudget;
       }
 
       if (instance != nullptr) {
@@ -945,6 +951,8 @@ namespace dxvk {
         }
       }
     }
+
+    replacementInstance->pendingMaterialization = anyPrimDeferredByBudget;
 
     processReplacementLights(input, pReplacements, replacementInstance);
     processReplacementGraphs(ctx, input, pReplacements, replacementInstance);
@@ -1342,15 +1350,40 @@ namespace dxvk {
   RtInstance* SceneManager::processDrawCallState(const Rc<DxvkContext>& ctx, const DrawCallState& drawCallState, const MaterialData& renderMaterialData, ReplacementInstance& replacementInstance, RtInstance* existingInstance, const RtxParticleSystemDesc* pParticleSystemDesc) {
     ScopedCpuProfileZone();
 
+    m_lastDrawDeferredByBudget = false;
+
     if (renderMaterialData.getIgnored()) {
       return nullptr;
     }
 
     ObjectCacheState result = ObjectCacheState::kInvalid;
     BlasEntry* pBlas = nullptr;
-    if (m_drawCallCache.get(drawCallState, &pBlas) == DrawCallCache::CacheState::kExisted) {
+    // Per-frame materialization budget: bound the triangles of NEW geometry
+    // (cache misses = full upload + BLAS build) admitted per frame. Admission
+    // is allowed while the frame's counter is still under budget (the last
+    // admission may overshoot by one mesh — a hard "must fit" rule would
+    // starve meshes larger than the budget whenever a trickle of small new
+    // geometry, e.g. particles, runs earlier in the frame's draw order).
+    // Over-budget draws are skipped without allocating an entry and retried on
+    // subsequent frames: originals via the game's per-frame resubmission,
+    // replacement prims via ReplacementInstance::pendingMaterialization which
+    // keeps the RI off the preserve path until nothing was deferred.
+    const uint32_t materializationBudget = RtxOptions::materializationBudgetTrianglesPerFrame();
+    bool allowNewGeometry = true;
+    uint32_t newGeometryTriangles = 0;
+    if (materializationBudget > 0) {
+      newGeometryTriangles = drawCallState.getGeometryData().calculatePrimitiveCount();
+      allowNewGeometry = m_materializedTrianglesThisFrame < materializationBudget;
+    }
+    const DrawCallCache::CacheState cacheState = m_drawCallCache.get(drawCallState, &pBlas, allowNewGeometry);
+    if (cacheState == DrawCallCache::CacheState::kRejectedBudget) {
+      m_lastDrawDeferredByBudget = true;
+      return nullptr;
+    }
+    if (cacheState == DrawCallCache::CacheState::kExisted) {
       result = onSceneObjectUpdated(ctx, drawCallState, pBlas);
     } else {
+      m_materializedTrianglesThisFrame += newGeometryTriangles;
       result = onSceneObjectAdded(ctx, drawCallState, pBlas);
     }
     

--- a/src/dxvk/rtx_render/rtx_scene_manager.h
+++ b/src/dxvk/rtx_render/rtx_scene_manager.h
@@ -367,6 +367,15 @@ private:
 
   DrawCallCache m_drawCallCache;
 
+  // Triangles of new geometry admitted for materialization this frame
+  // (rtx.materializationBudgetTrianglesPerFrame); reset in onFrameEnd.
+  uint32_t m_materializedTrianglesThisFrame = 0;
+
+  // True when the most recent processDrawCallState call skipped a NEW geometry
+  // because of the materialization budget (as opposed to returning nullptr for
+  // an ignored material). Read by callers that must retry next frame.
+  bool m_lastDrawDeferredByBudget = false;
+
   CameraManager m_cameraManager;
 
   std::unique_ptr<AssetReplacer> m_pReplacer;

--- a/src/dxvk/rtx_render/rtx_types.cpp
+++ b/src/dxvk/rtx_render/rtx_types.cpp
@@ -114,6 +114,7 @@ namespace dxvk {
     // the prim/root slots, the active-replacements tracking pointer, and the
     // cached aggregate bounding boxes so the RI is in a clean "no replacement
     // attached" state. setup() is the matching re-init.
+    pendingMaterialization = false;
     for (size_t i = 0; i < prims.size(); i++) {
       RtInstance* subInstance = prims[i].getInstance();
       if (subInstance) {

--- a/src/dxvk/rtx_render/rtx_types.h
+++ b/src/dxvk/rtx_render/rtx_types.h
@@ -252,6 +252,14 @@ struct ReplacementInstance {
   // Gates preserve vs dynamic dispatch and (future) split updaters. See DirtyFlag
   // and kLookupDriftMask / kDynamicFeatureMask for clear semantics.
   DirtyFlags dirtyFlags;
+
+  // Pending-work signal (boundingBoxDirty semantics, NOT dirtyFlags semantics —
+  // dirtyFlags is overwritten by computeDirtyFlags every submission): set when
+  // any prim of this RI was skipped by the per-frame materialization budget
+  // (rtx.materializationBudgetTrianglesPerFrame), cleared by the next
+  // drawReplacements pass that defers nothing. While set, the preserve path is
+  // bypassed so deferred prims are retried instead of persisting as holes.
+  bool pendingMaterialization = false;
 };
 
 // Wrapper utility to share the code for handling replacementInstance ownership.


### PR DESCRIPTION
New geometry materialization (vertex upload, interleave and BLAS build) runs synchronously in the draw submission path. A burst of newly visible meshes, for example when camera rotation brings previously culled objects back into the frustum, therefore lands in a single frame as one monolithic spike. Textures and opacity micromaps already have async streaming and per-frame build budgets respectively; geometry has no equivalent mechanism.

When `rtx.materializationBudgetTrianglesPerFrame` is greater than zero, new geometry (DrawCallCache misses) is admitted while the frame's running triangle counter is under the budget. The final admission may overshoot by one mesh, so a single mesh larger than the whole budget still loads. Over-budget draws are skipped without creating any state and retried on later frames: original draws through the game's own per-frame resubmission, replacement prims through a new `ReplacementInstance::pendingMaterialization` pending-work flag that keeps the instance off the preserve path until a pass defers nothing. Deferral trades the spike for one to three frames of pop-in at the frustum edge, where it is effectively invisible.

Default `0` preserves existing behavior exactly.

## Testing

Test game: Painkiller Black Edition with a USD mod containing mesh replacements (the case that motivated the change; any content where many replaced or new meshes enter the view at once will do).

1. Set `rtx.materializationBudgetTrianglesPerFrame = 500000` in `rtx.conf`.
2. Load a level with many replaced props and rotate the camera in place through a full turn several times, so off-screen objects repeatedly re-enter the frustum.

Before the change: each turn produces frame spikes of roughly 35 ms (measured via Tracy: the dxvk-cs thread stalls in geometry upload and BLAS build for the re-entering meshes, largest single offender 1.68M triangles in the test content).

After the change: the spikes are gone; per-frame new-geometry work is bounded by the budget. Deferred meshes appear within one to three frames. Verified with an instance-lifecycle log that deferred draws are retried and materialize (largest deferral observed resolved in 2 frames), and specifically that replacement prims deferred while their `ReplacementInstance` is being set up still materialize instead of persisting as holes; level geometry, pickups and effects all present after sustained play, level changes and reloads.

With the option at its default `0`, behavior is unchanged.
